### PR TITLE
add paperhash parameter

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -221,11 +221,13 @@ class Client(object):
 
 
 
-    def get_notes(self, id = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, includeTrash = None, number = None, limit = None, offset = None):
+    def get_notes(self, id = None, paperhash = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, includeTrash = None, number = None, limit = None, offset = None):
         """Returns a list of Note objects based on the filters provided."""
         params = {}
         if id != None:
             params['id'] = id
+        if paperhash != None:
+            params['paperhash'] = paperhash
         if forum != None:
             params['forum'] = forum
         if invitation != None:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='0.5.4.8',
+      version='0.5.5',
       description='OpenReview client library',
       url='https://github.com/iesl/openreview-py',
       author='Michael Spector, Melisa Bok',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='0.5.4.7',
+      version='0.5.4.8',
       description='OpenReview client library',
       url='https://github.com/iesl/openreview-py',
       author='Michael Spector, Melisa Bok',


### PR DESCRIPTION
@mzarozinski this is the way to call it:

```
openreview.get_notes(paperhash = 'kim|interpretable_3d_human_action_analysis_with_temporal_convolutional_networks')
```

Be sure that this index is in the database:

```
notesDb.ensureHashIndex('content.paperhash');
```