### PR TITLE
bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='0.6.2',
+      version='0.6.3',
       description='OpenReview client library',
       url='https://github.com/iesl/openreview-py',
       author='Michael Spector, Melisa Bok',


### PR DESCRIPTION
had to do this because, for some reason, it wouldn't let me upload 6.2 because it thought that it already existed, for some reason.

the advice online was to bump the version up, because a version cannot be removed once it's added