### PR TITLE
add kwargs to get notes function

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -256,7 +256,7 @@ class Client(object):
         invitations.sort(key = lambda x: x.id)
         return invitations
 
-    def get_notes(self, id = None, paperhash = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, includeTrash = None, number = None, limit = None, offset = None, mintcdate = None):
+    def get_notes(self, id = None, paperhash = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, includeTrash = None, number = None, limit = None, offset = None, mintcdate = None, details = None, **kwargs):
         """Returns a list of Note objects based on the filters provided."""
         params = {}
         if id != None:
@@ -285,7 +285,11 @@ class Client(object):
             params['offset'] = offset
         if mintcdate != None:
             params['mintcdate'] = mintcdate
+        if details != None:
+            params['details'] = details
 
+        for kw, arg in kwargs.iteritems():
+            params[kw] = arg
 
         response = requests.get(self.notes_url, params = params, headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -256,7 +256,7 @@ class Client(object):
         invitations.sort(key = lambda x: x.id)
         return invitations
 
-    def get_notes(self, id = None, paperhash = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, includeTrash = None, number = None, limit = None, offset = None, mintcdate = None, details = None, **kwargs):
+    def get_notes(self, id = None, paperhash = None, forum = None, invitation = None, replyto = None, tauthor = None, signature = None, writer = None, trash = None, number = None, limit = None, offset = None, mintcdate = None, details = None):
         """Returns a list of Note objects based on the filters provided."""
         params = {}
         if id != None:
@@ -275,7 +275,7 @@ class Client(object):
             params['signature'] = signature
         if writer != None:
             params['writer'] = writer
-        if includeTrash == True:
+        if trash == True:
             params['trash']=True
         if number != None:
             params['number'] = number
@@ -287,9 +287,6 @@ class Client(object):
             params['mintcdate'] = mintcdate
         if details != None:
             params['details'] = details
-
-        for kw, arg in kwargs.iteritems():
-            params[kw] = arg
 
         response = requests.get(self.notes_url, params = params, headers = self.headers)
         response = self.__handle_response(response)


### PR DESCRIPTION
adding **kwargs allows us to add arbitrary arguments, without breaking backwards compatibility (e.g. both trash and includeTrash arguments will work)

some advantages to **kwargs over explicitly naming the arguments:
- the API can evolve without us having to update the python library
- it's more readable

some disadvantages:
- you can't see what arguments are allowed just by looking at the function contract. but this isn't as much of a problem if we have central documentation for valid arguments.