### PR TITLE
add limit and offset to tag functions and add get_all_tags

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -312,7 +312,7 @@ class Client(object):
 
         return [Note.from_json(n) for n in response.json()['references']]
 
-    def get_tags(self, id = None, invitation = None, forum = None):
+    def get_tags(self, id = None, invitation = None, forum = None, limit = None, offset = None):
         """Returns a list of Tag objects based on the filters provided."""
         params = {}
 
@@ -322,6 +322,10 @@ class Client(object):
             params['forum'] = forum
         if invitation != None:
             params['invitation'] = invitation
+        if limit != None:
+            params['limit'] = limit
+        if offset != None:
+            params['offset'] = offset
 
         response = requests.get(self.tags_url, params = params, headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -245,17 +245,23 @@ def replace_members_with_ids(client, group):
     group.members = ids + emails
     client.post_group(group)
 
-def get_all_notes(client, invitation, limit=1000):
+def _get_all(get_function, invitation, limit):
     done = False
-    notes = []
+    objects = []
     offset = 0
     while not done:
-        batch = client.get_notes(invitation=invitation, limit=limit, offset=offset)
-        notes += batch
+        batch = get_function(invitation=invitation, limit=limit, offset=offset)
+        objects += batch
         offset += limit
         if len(batch) < limit:
             done = True
-    return notes
+    return objects
+
+def get_all_tags(client, invitation, limit=1000):
+    return _get_all(client.get_tags, invitation, limit)
+
+def get_all_notes(client, invitation, limit=1000):
+    return _get_all(client.get_notes, invitation, limit)
 
 def next_individual_suffix(unassigned_individual_groups, individual_groups, individual_label):
     '''


### PR DESCRIPTION
- generalizes the functionality in get_all_notes so that it can be used internally to get notes or tags.
- adds the get_all_tags function
- adds limit and offset parameters for the get_tags function