### PR TITLE
add iterget function/generator

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -67,9 +67,9 @@ def create_profile(client, email, first, last, middle = None, allow_duplicates =
 def build_groups(conference_group_id, default_params=None):
     '''
     Given a group ID, returns a list of empty groups that correspond to the given group's subpaths
-    
+
     (e.g. Test.com, Test.com/TestConference, Test.com/TestConference/2018)
-    
+
     >>> [group.id for group in build_groups('ICML.cc/2019/Conference')]
     [u'ICML.cc', u'ICML.cc/2019', u'ICML.cc/2019/Conference']
     '''
@@ -179,7 +179,7 @@ def get_bibtex(note, venue_fullname, year, url_forum=None, accepted=False, anony
 def subdomains(domain):
     '''
     Given an email address, returns a list with the domains and subdomains.
-    
+
     >>> subdomains('johnsmith@iesl.cs.umass.edu')
     [u'iesl.cs.umass.edu', u'cs.umass.edu', u'umass.edu']
     '''
@@ -346,23 +346,6 @@ def iterget(get_function, **kwargs):
         if len(batch) < params['limit']:
             done = True
 
-def _get_all(get_function, invitation, limit):
-    '''
-    Internal helper function for retrieving all objects of a certain type without
-    needing to set the limit in the API call.
-
-    '''
-    done = False
-    objects = []
-    offset = 0
-    while not done:
-        batch = get_function(invitation=invitation, limit=limit, offset=offset)
-        objects += batch
-        offset += limit
-        if len(batch) < limit:
-            done = True
-    return objects
-
 def get_all_tags(client, invitation, limit=1000):
     '''
     Given an invitation, returns all Tags that respond to it, ignoring API limit.
@@ -377,7 +360,7 @@ def get_all_notes(client, invitation, limit=1000):
 
 def next_individual_suffix(unassigned_individual_groups, individual_groups, individual_label):
     '''
-    |  "individual groups" are groups with a single member; 
+    |  "individual groups" are groups with a single member;
     |  e.g. conference.org/Paper1/AnonReviewer1
 
     :arg unassigned_individual_groups: a list of individual groups with no members
@@ -410,7 +393,7 @@ def get_reviewer_groups(client, paper_number, conference, group_params, parent_l
 
     '''
     This is only intended to be used as a local helper function
-    
+
     :arg paper_number: the number of the paper to assign
     :arg conference: the ID of the conference being assigned
     :arg group_params: optional parameter that overrides the default
@@ -464,7 +447,7 @@ def add_assignment(client, paper_number, conference, reviewer,
                     individual_group_params = {},
                     parent_label = 'Reviewers',
                     individual_label = 'AnonReviewer'):
-    
+
     '''
     |  Assigns a reviewer to a paper.
     |  Also adds the given user to the parent and individual groups defined by the paper number, conference, and labels
@@ -602,7 +585,7 @@ def assign(client, paper_number, conference,
     :arg reviewer_to_remove: same as @reviewer_to_add, but removes the user
 
     It's important to remove any users first, so that we can do direct replacement of one user with another.
-    
+
     For example: passing in a reviewer to remove AND a reviewer to add should replace the first user with the second.
     '''
     if reviewer_to_remove:
@@ -727,24 +710,24 @@ def post_submission_groups(client, conference_id, submission_invite, chairs):
 def get_submission_invitations(client, open_only=False):
     '''
     Returns a list of invitation ids visible to the client according to the value of parameter "open_only".
-    
+
     :arg client: Object of :class:`~openreview.Client` class
     :arg open_only: Default value is False. This is a boolean param with value True implying that the results would be invitations having a future due date.
-    
+
     Example Usage:
-    
+
     >>> get_submission_invitations(c,True)
     [u'machineintelligence.cc/MIC/2018/Conference/-/Submission', u'machineintelligence.cc/MIC/2018/Abstract/-/Submission', u'ISMIR.net/2018/WoRMS/-/Submission', u'OpenReview.net/Anonymous_Preprint/-/Submission']
     '''
-    
+
     #Calculate the epoch for current timestamp
     now = int(time.time()*1000)
     duedate = now if open_only==True else None
     invitations = client.get_invitations(regex='.*/-/.*[sS]ubmission.*',minduedate=duedate)
-    
+
     # For each group in the list, append the invitation id to a list
     invitation_ids = [inv.id for inv in invitations]
-    
+
     return invitation_ids
 
 def get_all_venues(client):

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -350,13 +350,13 @@ def get_all_tags(client, invitation, limit=1000):
     '''
     Given an invitation, returns all Tags that respond to it, ignoring API limit.
     '''
-    return [t for t in iterget(client.get_tags, invitation=invitation, limit=limit)]
+    return list(iterget(client.get_tags, invitation=invitation, limit=limit))
 
 def get_all_notes(client, invitation, limit=1000):
     '''
     Given an invitation, returns all Notes that respond to it, ignoring API limit.
     '''
-    return [n for n in iterget(client.get_notes, invitation=invitation, limit=limit)]
+    return list(iterget(client.get_notes, invitation=invitation, limit=limit))
 
 def next_individual_suffix(unassigned_individual_groups, individual_groups, individual_label):
     '''

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,3 +33,7 @@ class TestTools():
             counter += 1
 
         assert counter == data_size
+
+        notes_iterator = openreview.tools.iterget(self.client.get_notes)
+        notes_list = list(notes_iterator)
+        assert notes_list is not None, "Notes iterator failed"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import openreview
+import random
 
 class TestTools():
 
@@ -15,3 +16,20 @@ class TestTools():
     def test_get_all_venues(self):
         venues = openreview.get_all_venues(self.client)
         assert venues, "Venues could not be retrieved"
+
+    def test_iterget(self):
+        data_size = 1000
+        queue = [random.random() for _ in range(data_size)]
+
+        def mock_get(limit=100, offset=0):
+            return queue[offset:offset+limit]
+
+        assert data_size == len(list(openreview.tools.iterget(mock_get)))
+
+        new_iterator = openreview.tools.iterget(mock_get)
+
+        counter = 0
+        for random_real in new_iterator:
+            counter += 1
+
+        assert counter == data_size


### PR DESCRIPTION
this is useful if you want to retrieve a very large number of notes/references/invitations/groups but don't want to make all the network calls upfront or store them in memory.

(it's been useful to me as I've been working with the DBLP data)

This should make the _get_all() function sort of useless. If you like this change we can remove that function.