### PR TITLE
Fix/validate middle in create profile

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -63,8 +63,8 @@ def create_profile(client, email, first, last, middle = None, allow_duplicates =
         else:
             profile_exists = True
 
+        tilde_id = username_response_full['username']
         if (not profile_exists) or allow_duplicates:
-            tilde_id = username_response_full['username']
 
             tilde_group = openreview.Group(id = tilde_id, signatures = [super_user_id], signatories = [tilde_id], readers = [tilde_id], writers = [super_user_id], members = [email])
             email_group = openreview.Group(id = email, signatures = [super_user_id], signatories = [email], readers = [email], writers = [super_user_id], members = [tilde_id])


### PR DESCRIPTION
this fixes a bug where duplicates could make it through the validation even when `allow_duplicates` is set to `False`, if a profile exists with first, middle, and last name, but not first and last.

example:

- Profile called ~Samira_Ebrahimi_Kahou1 exists.
- We try to create a new profile with first=Samira, middle=Ebrahimi, last=Kahou
- Validator checks for ~Samira_Kahou1 and finds nothing, so allows us to create ~Samira_Ebrahimi_Kahou2 (this is bad)