### PR TITLE
enable templating of list fields

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -10,6 +10,7 @@ import openreview
 import re
 import datetime
 import time
+import ast
 from Crypto.Hash import HMAC, SHA256
 
 super_user_id = 'OpenReview.net'
@@ -914,6 +915,12 @@ def _fill_str(template_str, paper):
     for match in matches:
         discovered_field = re.sub('<|>', '', match)
         template_str = template_str.replace(match, str(paper_params[discovered_field]))
+        try:
+            evaluated_string = ast.literal_eval(template_str)
+            if type(evaluated_string) == list:
+                return evaluated_string
+        except ValueError as e:
+            pass
     return template_str
 
 def _fill_str_or_list(template_str_or_list, paper):


### PR DESCRIPTION
this change allows users to generate invitations with templates that refer to fields which are lists.

Before the change, these fields would return a string representation of a list, which would cause problems down the line. See examples:

```python
# Before the change
>> template = {'readers': '<readers>'}
>> openreview.tools.fill_template(template, paper)
{
  'readers': "['reader1', 'reader2', 'reader3']"
}
```

```python
# After the change
>> template = {'readers': '<readers>'}
>> openreview.tools.fill_template(template, paper)
{
  'readers': ['reader1', 'reader2', 'reader3']
}
```

I did a check of all our current usages of `fill_templates` and it looks like we're basically just using it to template the `number` and `forum` fields. This change is backwards compatible in that respect.