### PR TITLE
fix activate user

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -136,6 +136,20 @@ class Client(object):
         Activates a newly registered user
 
         :arg token: activation token
+        :arg content: content of the profile to activate
+
+        Example Usage:
+        >>> res = client.activate_user('new@user.com', { 
+            'names': [
+                    {
+                        'first': 'New',
+                        'last': 'User',
+                        'username': '~New_User1'
+                    }
+                ],
+            'emails': ['new@user.com'],
+            'preferredEmail': 'new@user.com'
+            })       
         '''
         response = requests.put(self.baseurl + '/activate/' + token, json = { 'content': content }, headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -131,13 +131,13 @@ class Client(object):
         response = self.__handle_response(response)
         return str(response.json())
 
-    def activate_user(self, token):
+    def activate_user(self, token, content):
         '''
         Activates a newly registered user
 
         :arg token: activation token
         '''
-        response = requests.put(self.baseurl + '/activate/' + token, headers = self.headers)
+        response = requests.put(self.baseurl + '/activate/' + token, json = { 'content': content }, headers = self.headers)
         response = self.__handle_response(response)
         return response.json()
 


### PR DESCRIPTION
Add content parameter to activate the user with profile info:

```
res = client.activate_user('new@user.com', { 
    'names': [
            {
                'first': 'New',
                'last': 'User',
                'username': '~New_User1'
            }
        ],
    'emails': ['new@user.com'],
    'preferredEmail': 'new@user.com'
    })
```

This only works in localhost, token is the email address. 