### PR TITLE
Feature/add local tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,15 @@ jobs:
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
       - run:
-          name: run app
+          name: install app
           command: |
             cd ~/openreview
             npm install
             node scripts/mongo_database.js
+      - run:
+          name: run app
+          command: |
+            cd ~/openreview
             node app
           background: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,13 @@ jobs:
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
-      - run: cd ~/openreview
-      - run: npm install
-      - run: node scripts/mongo_database.js
-      - run: node app
+      - run:
+          name: run app
+          command: |
+            cd ~/openreview
+            npm install
+            node scripts/mongo_database.js
+            node app
       - run: sudo pip install -U pytest
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             cd ~/openreview
             npm install
             node scripts/mongo_database.js
-            node app
+            node app &
       - run: sudo pip install -U pytest
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,10 @@ jobs:
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
-      - run:
-          name: run app
-          command: |
-            cd ~/openreview
-            node scripts/mongo_database.js
-            node app
+      - run: cd ~/openreview
+      - run: npm install
+      - run: node scripts/mongo_database.js
+      - run: node app
       - run: sudo pip install -U pytest
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,11 @@ jobs:
   build-py3:
     working_directory: ~/openreview-py-repo
     docker:
+      - image: circleci/node:8.9.1
       - image: circleci/python:3.6
+      - image: circleci/redis:3
+      - image: circleci/mongo:3.6
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
     steps:
       - checkout
       - run: sudo apt-get install python-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             cd ~/openreview
             npm install
-            node scripts/mongo_database.js
+            node scripts/setup.js
       - run:
           name: run app
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,13 @@ jobs:
             cd ~/openreview
             npm install
             node scripts/mongo_database.js
-            node app &
+            node app
+          background: true
+      - run:
+          shell: /bin/sh
+          command: |
+            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:3000
+            :
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
     steps:
       - checkout
+      - run: sudo apt-get install python-pip
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
             npm install
             node scripts/mongo_database.js
             node app &
-      - run: sudo pip install -U pytest
       - run:
           name: run tests
           command: |
             cd ~/openreview-py-repo
+            sudo pip install -U pytest
             mkdir test-reports
             pytest --junitxml=test-reports/junit.xml
       - store_test_results:
@@ -64,7 +64,7 @@ workflows:
   build-deploy:
     jobs:
       - build
-      - build-py3
+      #- build-py3
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,21 +47,6 @@ jobs:
       #     path: test-reports
       # - store_artifacts:
       #     path: test-reports
-  test:
-    working_directory: ~/openreview-py-repo
-    docker:
-
-    steps:
-      - run: sudo pip install -U pytest
-      - run:
-          name: run tests
-          command: |
-            mkdir test-reports
-            pytest --junitxml=test-reports/junit.xml
-      - store_test_results:
-          path: test-reports
-      - store_artifacts:
-          path: test-reports
   deploy:
     working_directory: ~/openreview-py-repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: sudo apt-get install python-setuptools
       - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
-      - run: git clone -b feature/circle-ci-config https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
       - run:
           name: install app
@@ -58,7 +58,7 @@ jobs:
       - run: sudo apt-get install python-setuptools
       - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
-      - run: git clone -b feature/circle-ci-config https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: git clone -b https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
       - run:
           name: install app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,16 @@ jobs:
     steps:
       - checkout
       - run: sudo pip install ~/openreview-py-repo
-      - run: sudo pip install -U pytest
-      - run:
-          name: run tests
-          command: |
-            mkdir test-reports
-            pytest --junitxml=test-reports/junit.xml
-      - store_test_results:
-          path: test-reports
-      - store_artifacts:
-          path: test-reports
+      # - run: sudo pip install -U pytest
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       mkdir test-reports
+      #       pytest --junitxml=test-reports/junit.xml
+      # - store_test_results:
+      #     path: test-reports
+      # - store_artifacts:
+      #     path: test-reports
   build-py3:
     working_directory: ~/openreview-py-repo
     docker:
@@ -24,6 +24,25 @@ jobs:
     steps:
       - checkout
       - run: sudo pip install ~/openreview-py-repo
+      # - run: sudo pip install -U pytest
+      # - run:
+      #     name: run tests
+      #     command: |
+      #       mkdir test-reports
+      #       pytest --junitxml=test-reports/junit.xml
+      # - store_test_results:
+      #     path: test-reports
+      # - store_artifacts:
+      #     path: test-reports
+  test:
+    working_directory: ~/openreview-py-repo
+    docker:
+      - image: circleci/node:8.9.1
+      - image: circleci/redis:3
+      - image: circleci/mongo:3.6
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
+    steps:
+      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git
       - run: sudo pip install -U pytest
       - run:
           name: run tests
@@ -49,9 +68,12 @@ workflows:
     jobs:
       - build
       - build-py3
-      - deploy:
+      - test:
           requires:
             - build
+      - deploy:
+          requires:
+            - test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get install python-dev
+      - run: sudo apt-get install python-setuptools
       - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
     steps:
       - checkout
+      - run: sudo apt-get install python-dev
       - run: sudo apt-get install python-pip
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ jobs:
   build:
     working_directory: ~/openreview-py-repo
     docker:
-      - image: circleci/python:2.7
       - image: circleci/node:8.9.1
+      - image: circleci/python:2.7
       - image: circleci/redis:3
       - image: circleci/mongo:3.6
       - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get install python-dev
-      - run: sudo apt-get install python-pip
+      - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
       - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,19 +14,19 @@ jobs:
       - run: sudo apt-get install python-setuptools
       - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
-      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: git clone -b feature/circle-ci-config https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
       - run:
           name: install app
           command: |
             cd ~/openreview
             npm install
-            node scripts/setup.js
+            NODE_ENV=circleci node scripts/setup.js
       - run:
           name: run app
           command: |
             cd ~/openreview
-            node app
+            NODE_ENV=circleci node app
           background: true
       - run:
           shell: /bin/sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,32 @@ jobs:
     working_directory: ~/openreview-py-repo
     docker:
       - image: circleci/python:2.7
+      - image: circleci/node:8.9.1
+      - image: circleci/redis:3
+      - image: circleci/mongo:3.6
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
     steps:
       - checkout
       - run: sudo pip install ~/openreview-py-repo
-      # - run: sudo pip install -U pytest
-      # - run:
-      #     name: run tests
-      #     command: |
-      #       mkdir test-reports
-      #       pytest --junitxml=test-reports/junit.xml
-      # - store_test_results:
-      #     path: test-reports
-      # - store_artifacts:
-      #     path: test-reports
+      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: mkdir ~/openreview/logs
+      - run:
+          name: run app
+          command: |
+            cd ~/openreview
+            node scripts/mongo_database.js
+            node app
+      - run: sudo pip install -U pytest
+      - run:
+          name: run tests
+          command: |
+            cd ~/openreview-py-repo
+            mkdir test-reports
+            pytest --junitxml=test-reports/junit.xml
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
   build-py3:
     working_directory: ~/openreview-py-repo
     docker:
@@ -37,12 +50,8 @@ jobs:
   test:
     working_directory: ~/openreview-py-repo
     docker:
-      - image: circleci/node:8.9.1
-      - image: circleci/redis:3
-      - image: circleci/mongo:3.6
-      - image: docker.elastic.co/elasticsearch/elasticsearch:6.2.2
+
     steps:
-      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git
       - run: sudo pip install -U pytest
       - run:
           name: run tests
@@ -68,12 +77,9 @@ workflows:
     jobs:
       - build
       - build-py3
-      - test:
-          requires:
-            - build
       - deploy:
           requires:
-            - test
+            - build
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run: sudo apt-get install python-setuptools
       - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
-      - run: git clone -b https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: git clone https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
       - run: mkdir ~/openreview/logs
       - run:
           name: install app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,17 +50,40 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
+      - run: sudo apt-get install python-dev
+      - run: sudo apt-get install python-setuptools
+      - run: sudo easy_install pip
       - run: sudo pip install ~/openreview-py-repo
-      # - run: sudo pip install -U pytest
-      # - run:
-      #     name: run tests
-      #     command: |
-      #       mkdir test-reports
-      #       pytest --junitxml=test-reports/junit.xml
-      # - store_test_results:
-      #     path: test-reports
-      # - store_artifacts:
-      #     path: test-reports
+      - run: git clone -b feature/circle-ci-config https://$OPENREVIEW_GITHUB@github.com/iesl/openreview.git ~/openreview
+      - run: mkdir ~/openreview/logs
+      - run:
+          name: install app
+          command: |
+            cd ~/openreview
+            npm install
+            NODE_ENV=circleci node scripts/setup.js
+      - run:
+          name: run app
+          command: |
+            cd ~/openreview
+            NODE_ENV=circleci node app
+          background: true
+      - run:
+          shell: /bin/sh
+          command: |
+            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:3000
+            :
+      - run:
+          name: run tests
+          command: |
+            cd ~/openreview-py-repo
+            sudo pip install -U pytest
+            mkdir test-reports
+            pytest --junitxml=test-reports/junit.xml
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
   deploy:
     working_directory: ~/openreview-py-repo
     docker:
@@ -75,7 +98,7 @@ workflows:
   build-deploy:
     jobs:
       - build
-      #- build-py3
+      - build-py3
       - deploy:
           requires:
             - build

--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ remove_members_from_group(self, group, members):
 
 [Link](http://openreview-py.readthedocs.io/en/latest/) to full Documentation
 
+
+Run tests
+----------
+
+To run the tests of the library you need to have the OpenReview backend running in your localhost.
+
+Checkout the code and run
+
+```bash
+NODE_ENV=test node scripts/clean_start_app.js
+```

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -56,11 +56,15 @@ class Client(object):
         self.headers = {'User-Agent': 'test-create-script'}
         if(self.username!=None and self.password!=None):
             self.login_user(self.username, self.password)
-            self.headers['Authorization'] ='Bearer ' + self.token
             self.signature = self.get_profile(self.username).id
 
 
     ## PRIVATE FUNCTIONS
+
+    def __handle_token(self, response):
+        self.token = str(response['token'])
+        self.headers['Authorization'] ='Bearer ' + self.token
+        return response
 
     def __handle_response(self,response):
         try:
@@ -86,12 +90,11 @@ class Client(object):
         Logs in a registered user and returns authentication token
         '''
         user = { 'id': username, 'password': password }
-        print(user)
         header = { 'User-Agent': 'test-create-script' }
         response = requests.post(self.login_url, headers=header, json=user)
         response = self.__handle_response(response)
         json_response = response.json()
-        self.token = str(json_response['token'])
+        self.__handle_token(json_response)
         return json_response
 
     def register_user(self, email = None, first = None, last = None, middle = '', password = None):
@@ -129,7 +132,10 @@ class Client(object):
         '''
         response = requests.put(self.baseurl + '/activate/' + token, json = { 'content': content }, headers = self.headers)
         response = self.__handle_response(response)
-        return response.json()
+        json_response = response.json()
+        self.__handle_token(json_response)
+
+        return json_response
 
     def get_activatable(self, token = None):
         '''
@@ -137,8 +143,8 @@ class Client(object):
         '''
         response = requests.get(self.baseurl + '/activatable/' + token, params = {}, headers = self.headers)
         response = self.__handle_response(response)
-        token = response.json()['activatable']['token']
-        return token
+        self.__handle_token(response.json()['activatable'])
+        return self.token
 
     def get_group(self, id):
         """

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -29,20 +29,17 @@ class Client(object):
 
         :arg password: openreview password. Optional argument.
         """
-        if not baseurl:
+        self.baseurl = baseurl
+        if not self.baseurl:
             self.baseurl = os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3000')
-        else:
-            self.baseurl = baseurl
 
+        self.username = username
         if not username:
             self.username = os.environ.get('OPENREVIEW_USERNAME')
-        else:
-            self.username = username
 
+        self.password = password
         if not password:
             self.password = os.environ.get('OPENREVIEW_PASSWORD')
-        else:
-            self.password = password
 
         self.groups_url = self.baseurl + '/groups'
         self.login_url = self.baseurl + '/login'
@@ -88,25 +85,14 @@ class Client(object):
         '''
         Logs in a registered user and returns authentication token
         '''
-        if username==None:
-            try:
-                username = os.environ["OPENREVIEW_USERNAME"]
-            except KeyError:
-                pass
-
-        if password==None:
-            try:
-                password = os.environ["OPENREVIEW_PASSWORD"]
-            except KeyError:
-                pass
-
-        user = {'id':username,'password':password}
-        header = {'User-Agent': 'test-create-script'}
+        user = { 'id': username, 'password': password }
+        print(user)
+        header = { 'User-Agent': 'test-create-script' }
         response = requests.post(self.login_url, headers=header, json=user)
         response = self.__handle_response(response)
-        self.token = str(response.json()['token'])
-
-        return response
+        json_response = response.json()
+        self.token = str(json_response['token'])
+        return json_response
 
     def register_user(self, email = None, first = None, last = None, middle = '', password = None):
         '''

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -13,7 +13,6 @@ import os
 import getpass
 import re
 import datetime
-import builtins
 
 
 
@@ -30,27 +29,18 @@ class Client(object):
 
         :arg password: openreview password. Optional argument.
         """
-        if baseurl==None:
-            try:
-                self.baseurl = os.environ['OPENREVIEW_BASEURL']
-            except KeyError:
-                self.baseurl = builtins.input('Environment variable OPENREVIEW_BASEURL not found. Please provide a base URL: ')
+        if not baseurl:
+            self.baseurl = os.environ.get('OPENREVIEW_BASEURL', 'http://localhost:3000')
         else:
             self.baseurl = baseurl
 
-        if username==None:
-            try:
-                self.username = os.environ['OPENREVIEW_USERNAME']
-            except KeyError:
-                self.username = username
+        if not username:
+            self.username = os.environ.get('OPENREVIEW_USERNAME')
         else:
             self.username = username
 
-        if password==None:
-            try:
-                self.password = os.environ['OPENREVIEW_PASSWORD']
-            except KeyError:
-                self.password = password
+        if not password:
+            self.password = os.environ.get('OPENREVIEW_PASSWORD')
         else:
             self.password = password
 
@@ -139,7 +129,7 @@ class Client(object):
         :arg content: content of the profile to activate
 
         Example Usage:
-        >>> res = client.activate_user('new@user.com', { 
+        >>> res = client.activate_user('new@user.com', {
             'names': [
                     {
                         'first': 'New',
@@ -149,7 +139,7 @@ class Client(object):
                 ],
             'emails': ['new@user.com'],
             'preferredEmail': 'new@user.com'
-            })       
+            })
         '''
         response = requests.put(self.baseurl + '/activate/' + token, json = { 'content': content }, headers = self.headers)
         response = self.__handle_response(response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,9 +7,9 @@ import pytest
 def client():
     client = openreview.Client()
     assert client is not None, "Client is none"
-    res = client.register_user(email = 'OpenReview.net', first = 'Super', last = 'User', password = '1234')
+    res = client.register_user(email = 'openreview.net', first = 'Super', last = 'User', password = '1234')
     assert res, "Res i none"
-    res = client.activate_user('OpenReview.net', {
+    res = client.activate_user('openreview.net', {
         'names': [
                 {
                     'first': 'Super',
@@ -21,6 +21,9 @@ def client():
         'preferredEmail': 'openreview.net'
         })
     assert res, "Res i none"
+    group = client.get_group(id = 'openreview.net')
+    assert group
+    assert group.members == ['~Super_User1']
     yield client
 
 class TestClient():
@@ -31,17 +34,20 @@ class TestClient():
 
     def test_get_groups(self, client):
         groups = client.get_groups()
-        assert len(groups) == 6, 'groups is empty'
+        assert len(groups) == 8, 'groups is empty'
         assert groups[0].id == '(anonymous)'
         assert groups[1].id == 'everyone'
         assert groups[2].id == '~'
         assert groups[3].id == '(guest)'
-        assert groups[4].id == 'active_venues'
-        assert groups[5].id == 'host'
+        assert groups[4].id == '~Super_User1'
+        assert groups[5].id == 'openreview.net'
+        assert groups[6].id == 'active_venues'
+        assert groups[7].id == 'host'
 
     def test_get_invitations(self, client):
         invitations = client.get_invitations()
-        assert len(invitations) == 0, 'invitations is not empty'
+        assert len(invitations) == 1, 'invitations is not empty'
+        assert invitations[0].id == '~/-/profiles'
 
     def test_login_user(self):
         try:
@@ -119,28 +125,31 @@ class TestClient():
         profile = client.get_profile('~Super_User1')
         assert profile, "Could not get the profile by id"
         assert isinstance(profile, openreview.Profile)
-        assert 'o****t' in profile.content['emails']
+        assert 'openreview.net' in profile.content['emails']
 
         with pytest.raises(openreview.OpenReviewException, match=r'.*Profile not found.*'):
             profile = client.get_profile('mbok@sss.edu')
 
-    # def test_get_profiles(self):
-    #     profiles = self.client.get_profiles(['mbok@cs.umass.edu'])
-    #     assert profiles, "Could not get the profile by email"
-    #     assert isinstance(profiles, dict)
-    #     assert isinstance(profiles['mbok@cs.umass.edu'], openreview.Profile)
-    #     assert profiles['mbok@cs.umass.edu'].id == '~Melisa_TestBok1'
+    def test_get_profiles(self, client):
+        guest = openreview.Client()
+        guest.register_user(email = 'mbok@mail.com', first = 'Melisa', last = 'Bok', password = '1234')
+        guest.register_user(email = 'andrew@mail.com', first = 'Andrew', last = 'McCallum', password = '1234')
 
-    #     profiles = self.client.get_profiles(['~Melisa_TestBok1', '~Andrew_McCallum1'])
-    #     assert profiles, "Could not get the profile by id"
-    #     assert isinstance(profiles, list)
-    #     print(profiles)
-    #     assert len(profiles) == 2
-    #     assert '~Melisa_TestBok1' in profiles[1].id
-    #     assert '~Andrew_McCallum1' in profiles[0].id
+        profiles = client.get_profiles(['mbok@mail.com'])
+        assert profiles, "Could not get the profile by email"
+        assert isinstance(profiles, dict)
+        assert isinstance(profiles['mbok@mail.com'], openreview.Profile)
+        assert profiles['mbok@mail.com'].id == '~Melisa_Bok1'
 
-    #     profiles = self.client.get_profiles([])
-    #     assert len(profiles) == 0
+        profiles = client.get_profiles(['~Melisa_Bok1', '~Andrew_McCallum1'])
+        assert profiles, "Could not get the profile by id"
+        assert isinstance(profiles, list)
+        assert len(profiles) == 2
+        assert '~Melisa_Bok1' in profiles[1].id
+        assert '~Andrew_McCallum1' in profiles[0].id
+
+        profiles = client.get_profiles([])
+        assert len(profiles) == 0
 
     # def test_get_invitations(self):
     #     invitations = self.client.get_invitations(invitee = '~', pastdue = False)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,44 +77,9 @@ class TestClient():
         venues = openreview.tools.get_all_venues(guest)
         assert len(venues) == 0, "Venues could not be retrieved for guest user"
 
-    # def test_get_notes_with_details(self):
-    #     notes = self.client.get_notes(invitation = 'ICLR.cc/2018/Conference/-/Blind_Submission', details='all')
-    #     assert notes, 'notes is None'
-    #     assert len(notes) > 0, 'notes is empty'
-    #     assert notes[0].details, 'notes does not have details'
-    #     assert isinstance(notes[0].details, dict), 'notes does not have details'
-    #     assert isinstance(notes[0].details['tags'], list), 'note does not have tags'
-    #     assert isinstance(notes[0].details['replyCount'], int), 'note does not have replyCount'
-    #     assert isinstance(notes[0].details['revisions'], bool), 'note does not have revisions'
-    #     assert isinstance(notes[0].details['overwriting'], list), 'note does not have overwriting'
-    #     assert isinstance(notes[0].details['writable'], bool), 'note does not have writable'
-
-    # # def test_get_pdf(self):
-    # #     # Testing a valid PDF id
-    # #     pdf_content = self.client.get_pdf(id='HJBhFJTF-')
-    # #     assert pdf_content, "get_pdf did not return anything"
-
-    # #     # Testing an invalid PDF id
-    # #     try:
-    # #         pdf_content = self.client.get_pdf(id='AnInvalidID')
-    # #     except openreview.OpenReviewException as e:
-    # #         assert 'Not Found' in e.args[0][0]['type'], "Incorrect error observed with invalid Note ID"
-
-    # def test_put_pdf(self, client):
-    #     # Calling put_pdf without a valid file name
-    #     try:
-    #         response = client.put_pdf(fname='')
-    #     except IOError as e:
-    #         assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
-
-    #     # Creating an empty PDF and then uploading it
-    #     f = open("empty_test.pdf",'wb')
-    #     f.close()
-    #     response = client.put_pdf('empty_test.pdf')
-
-    #     if os.path.exists("empty_test.pdf"):
-    #         os.remove("empty_test.pdf")
-    #     assert "/pdf/" in response, "PDF not uploaded properly"
+    def test_get_notes_with_details(self, client):
+        notes = client.get_notes(invitation = 'ICLR.cc/2018/Conference/-/Blind_Submission', details='all')
+        assert len(notes) == 0, 'notes is empty'
 
     def test_get_profile(self, client):
         profile = client.get_profile('openreview.net')
@@ -151,21 +116,18 @@ class TestClient():
         profiles = client.get_profiles([])
         assert len(profiles) == 0
 
-    # def test_get_invitations(self):
-    #     invitations = self.client.get_invitations(invitee = '~', pastdue = False)
-    #     assert invitations
-    #     assert len(invitations) > 0
+    def test_get_invitations(self, client):
+        invitations = client.get_invitations(invitee = '~', pastdue = False)
+        assert len(invitations) == 0
 
-    #     invitations = self.client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
-    #     assert invitations
-    #     assert len(invitations) > 0
-    #     assert invitations[0].details
+        invitations = client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
+        assert len(invitations) == 0
 
-    #     invitations = self.client.get_invitations(invitee = True, duedate = True, replyto = True, details = 'replytoNote,repliedNotes')
-    #     assert len(invitations) == 0
+        invitations = client.get_invitations(invitee = True, duedate = True, replyto = True, details = 'replytoNote,repliedNotes')
+        assert len(invitations) == 0
 
-    #     invitations = self.client.get_invitations(invitee = True, duedate = True, tags = True, details = 'repliedTags')
-    #     assert len(invitations) == 0
+        invitations = client.get_invitations(invitee = True, duedate = True, tags = True, details = 'repliedTags')
+        assert len(invitations) == 0
 
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,131 +3,159 @@ import os
 import openreview
 import pytest
 
+@pytest.fixture(scope='class')
+def client():
+    client = openreview.Client()
+    assert client is not None, "Client is none"
+    res = client.register_user(email = 'OpenReview.net', first = 'Super', last = 'User', password = '1234')
+    assert res, "Res i none"
+    res = client.activate_user('OpenReview.net', {
+        'names': [
+                {
+                    'first': 'Super',
+                    'last': 'User',
+                    'username': '~Super_User1'
+                }
+            ],
+        'emails': ['openreview.net'],
+        'preferredEmail': 'openreview.net'
+        })
+    assert res, "Res i none"
+    yield client
+
 class TestClient():
 
-    def setup_method(self, method):
-        # Password should be saved in the environment variable OPENREVIEW_PASSWORD
-        self.client = openreview.Client(username = "OpenReview.net", password = '1234')
-        assert self.client is not None, "Client is none"
-        self.guest = openreview.Client()
-        assert self.guest is not None, "Guest is none"
+    def test_get_notes(self, client):
+        notes = client.get_notes()
+        assert len(notes) == 0, 'notes is not empty'
 
-    def test_get_notes(self):
-        notes = self.client.get_notes()
-        assert notes, 'notes is None'
-        assert len(notes) == 1000, 'notes is not max limit'
+    def test_get_groups(self, client):
+        groups = client.get_groups()
+        assert len(groups) == 6, 'groups is empty'
+        assert groups[0].id == '(anonymous)'
+        assert groups[1].id == 'everyone'
+        assert groups[2].id == '~'
+        assert groups[3].id == '(guest)'
+        assert groups[4].id == 'active_venues'
+        assert groups[5].id == 'host'
 
-    def test_get_groups(self):
-        groups = self.client.get_groups()
-        assert groups, 'groups is None'
-        assert len(groups) == 1004, 'groups is not max limit'
-
-    def test_get_invitations(self):
-        invitations = self.client.get_invitations()
-        assert invitations, 'invitations is None'
-        assert len(invitations) == 1000, 'invitations is not max limit'
+    def test_get_invitations(self, client):
+        invitations = client.get_invitations()
+        assert len(invitations) == 0, 'invitations is not empty'
 
     def test_login_user(self):
         try:
-            response = self.guest.login_user()
+            guest = openreview.Client()
+            guest.login_user()
         except openreview.OpenReviewException as e:
             assert ["Email is missing"] in e.args, "guest log in did not produce correct error"
 
-        response = self.guest.login_user(username = "OpenReview.net")
-        assert response, "valid token not found"
-
-    def test_guest_user(self):
-        invitations = openreview.tools.get_submission_invitations(self.guest)
-        assert invitations, "Invitations could not be retrieved for guest user"
-        venues = openreview.tools.get_all_venues(self.guest)
-        assert venues, "Venues could not be retrieved for guest user"
-
-    def test_get_notes_with_details(self):
-        notes = self.client.get_notes(invitation = 'ICLR.cc/2018/Conference/-/Blind_Submission', details='all')
-        assert notes, 'notes is None'
-        assert len(notes) > 0, 'notes is empty'
-        assert notes[0].details, 'notes does not have details'
-        assert isinstance(notes[0].details, dict), 'notes does not have details'
-        assert isinstance(notes[0].details['tags'], list), 'note does not have tags'
-        assert isinstance(notes[0].details['replyCount'], int), 'note does not have replyCount'
-        assert isinstance(notes[0].details['revisions'], bool), 'note does not have revisions'
-        assert isinstance(notes[0].details['overwriting'], list), 'note does not have overwriting'
-        assert isinstance(notes[0].details['writable'], bool), 'note does not have writable'
-
-    # def test_get_pdf(self):
-    #     # Testing a valid PDF id
-    #     pdf_content = self.client.get_pdf(id='HJBhFJTF-')
-    #     assert pdf_content, "get_pdf did not return anything"
-
-    #     # Testing an invalid PDF id
-    #     try:
-    #         pdf_content = self.client.get_pdf(id='AnInvalidID')
-    #     except openreview.OpenReviewException as e:
-    #         assert 'Not Found' in e.args[0][0]['type'], "Incorrect error observed with invalid Note ID"
-
-    def test_put_pdf(self):
-        # Calling put_pdf without a valid file name
         try:
-            response = self.client.put_pdf(fname='')
-        except IOError as e:
-            assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
+            guest.login_user(username = "openreview.net")
+        except openreview.OpenReviewException as e:
+            assert ["Password is missing"] in e.args, "super user log in did not produce correct error"
 
-        # Creating an empty PDF and then uploading it
-        f = open("empty_test.pdf",'wb')
-        f.close()
-        response = self.client.put_pdf('empty_test.pdf')
+        try:
+            guest.login_user(username = "openreview.net", password = "1111")
+        except openreview.OpenReviewException as e:
+            assert ["Invalid username or password"] in e.args, "super user log in did not produce correct error"
 
-        if os.path.exists("empty_test.pdf"):
-            os.remove("empty_test.pdf")
-        assert "/pdf/" in response, "PDF not uploaded properly"
+        response = guest.login_user(username = "openreview.net", password = "1234")
+        assert response
+        print(response)
 
-    def test_get_profile(self):
-        profile = self.client.get_profile('mbok@cs.umass.edu')
-        assert profile, "Could not get the profile by email"
-        assert isinstance(profile, openreview.Profile)
-        assert profile.id == '~Melisa_TestBok1'
+    # def test_guest_user(self):
+    #     invitations = openreview.tools.get_submission_invitations(self.guest)
+    #     assert invitations, "Invitations could not be retrieved for guest user"
+    #     venues = openreview.tools.get_all_venues(self.guest)
+    #     assert venues, "Venues could not be retrieved for guest user"
 
-        profile = self.client.get_profile('~Melisa_TestBok1')
-        assert profile, "Could not get the profile by id"
-        assert isinstance(profile, openreview.Profile)
-        assert 'mbok@cs.umass.edu' in profile.content['emails']
+    # def test_get_notes_with_details(self):
+    #     notes = self.client.get_notes(invitation = 'ICLR.cc/2018/Conference/-/Blind_Submission', details='all')
+    #     assert notes, 'notes is None'
+    #     assert len(notes) > 0, 'notes is empty'
+    #     assert notes[0].details, 'notes does not have details'
+    #     assert isinstance(notes[0].details, dict), 'notes does not have details'
+    #     assert isinstance(notes[0].details['tags'], list), 'note does not have tags'
+    #     assert isinstance(notes[0].details['replyCount'], int), 'note does not have replyCount'
+    #     assert isinstance(notes[0].details['revisions'], bool), 'note does not have revisions'
+    #     assert isinstance(notes[0].details['overwriting'], list), 'note does not have overwriting'
+    #     assert isinstance(notes[0].details['writable'], bool), 'note does not have writable'
 
-        with pytest.raises(openreview.OpenReviewException, match=r'.*Profile not found.*'):
-            profile = self.client.get_profile('mbok@sss.edu')
+    # # def test_get_pdf(self):
+    # #     # Testing a valid PDF id
+    # #     pdf_content = self.client.get_pdf(id='HJBhFJTF-')
+    # #     assert pdf_content, "get_pdf did not return anything"
 
-    def test_get_profiles(self):
-        profiles = self.client.get_profiles(['mbok@cs.umass.edu'])
-        assert profiles, "Could not get the profile by email"
-        assert isinstance(profiles, dict)
-        assert isinstance(profiles['mbok@cs.umass.edu'], openreview.Profile)
-        assert profiles['mbok@cs.umass.edu'].id == '~Melisa_TestBok1'
+    # #     # Testing an invalid PDF id
+    # #     try:
+    # #         pdf_content = self.client.get_pdf(id='AnInvalidID')
+    # #     except openreview.OpenReviewException as e:
+    # #         assert 'Not Found' in e.args[0][0]['type'], "Incorrect error observed with invalid Note ID"
 
-        profiles = self.client.get_profiles(['~Melisa_TestBok1', '~Andrew_McCallum1'])
-        assert profiles, "Could not get the profile by id"
-        assert isinstance(profiles, list)
-        print(profiles)
-        assert len(profiles) == 2
-        assert '~Melisa_TestBok1' in profiles[1].id
-        assert '~Andrew_McCallum1' in profiles[0].id
+    # def test_put_pdf(self):
+    #     # Calling put_pdf without a valid file name
+    #     try:
+    #         response = self.client.put_pdf(fname='')
+    #     except IOError as e:
+    #         assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
 
-        profiles = self.client.get_profiles([])
-        assert len(profiles) == 0
+    #     # Creating an empty PDF and then uploading it
+    #     f = open("empty_test.pdf",'wb')
+    #     f.close()
+    #     response = self.client.put_pdf('empty_test.pdf')
 
-    def test_get_invitations(self):
-        invitations = self.client.get_invitations(invitee = '~', pastdue = False)
-        assert invitations
-        assert len(invitations) > 0
+    #     if os.path.exists("empty_test.pdf"):
+    #         os.remove("empty_test.pdf")
+    #     assert "/pdf/" in response, "PDF not uploaded properly"
 
-        invitations = self.client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
-        assert invitations
-        assert len(invitations) > 0
-        assert invitations[0].details
+    # def test_get_profile(self):
+    #     profile = self.client.get_profile('mbok@cs.umass.edu')
+    #     assert profile, "Could not get the profile by email"
+    #     assert isinstance(profile, openreview.Profile)
+    #     assert profile.id == '~Melisa_TestBok1'
 
-        invitations = self.client.get_invitations(invitee = True, duedate = True, replyto = True, details = 'replytoNote,repliedNotes')
-        assert len(invitations) == 0
+    #     profile = self.client.get_profile('~Melisa_TestBok1')
+    #     assert profile, "Could not get the profile by id"
+    #     assert isinstance(profile, openreview.Profile)
+    #     assert 'mbok@cs.umass.edu' in profile.content['emails']
 
-        invitations = self.client.get_invitations(invitee = True, duedate = True, tags = True, details = 'repliedTags')
-        assert len(invitations) == 0
+    #     with pytest.raises(openreview.OpenReviewException, match=r'.*Profile not found.*'):
+    #         profile = self.client.get_profile('mbok@sss.edu')
+
+    # def test_get_profiles(self):
+    #     profiles = self.client.get_profiles(['mbok@cs.umass.edu'])
+    #     assert profiles, "Could not get the profile by email"
+    #     assert isinstance(profiles, dict)
+    #     assert isinstance(profiles['mbok@cs.umass.edu'], openreview.Profile)
+    #     assert profiles['mbok@cs.umass.edu'].id == '~Melisa_TestBok1'
+
+    #     profiles = self.client.get_profiles(['~Melisa_TestBok1', '~Andrew_McCallum1'])
+    #     assert profiles, "Could not get the profile by id"
+    #     assert isinstance(profiles, list)
+    #     print(profiles)
+    #     assert len(profiles) == 2
+    #     assert '~Melisa_TestBok1' in profiles[1].id
+    #     assert '~Andrew_McCallum1' in profiles[0].id
+
+    #     profiles = self.client.get_profiles([])
+    #     assert len(profiles) == 0
+
+    # def test_get_invitations(self):
+    #     invitations = self.client.get_invitations(invitee = '~', pastdue = False)
+    #     assert invitations
+    #     assert len(invitations) > 0
+
+    #     invitations = self.client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
+    #     assert invitations
+    #     assert len(invitations) > 0
+    #     assert invitations[0].details
+
+    #     invitations = self.client.get_invitations(invitee = True, duedate = True, replyto = True, details = 'replytoNote,repliedNotes')
+    #     assert len(invitations) == 0
+
+    #     invitations = self.client.get_invitations(invitee = True, duedate = True, tags = True, details = 'repliedTags')
+    #     assert len(invitations) == 0
 
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -64,11 +64,12 @@ class TestClient():
         assert response
         print(response)
 
-    # def test_guest_user(self):
-    #     invitations = openreview.tools.get_submission_invitations(self.guest)
-    #     assert invitations, "Invitations could not be retrieved for guest user"
-    #     venues = openreview.tools.get_all_venues(self.guest)
-    #     assert venues, "Venues could not be retrieved for guest user"
+    def test_guest_user(self):
+        guest = openreview.Client()
+        invitations = openreview.tools.get_submission_invitations(guest)
+        assert len(invitations) == 0, "Invitations could not be retrieved for guest user"
+        venues = openreview.tools.get_all_venues(guest)
+        assert len(venues) == 0, "Venues could not be retrieved for guest user"
 
     # def test_get_notes_with_details(self):
     #     notes = self.client.get_notes(invitation = 'ICLR.cc/2018/Conference/-/Blind_Submission', details='all')
@@ -93,35 +94,35 @@ class TestClient():
     # #     except openreview.OpenReviewException as e:
     # #         assert 'Not Found' in e.args[0][0]['type'], "Incorrect error observed with invalid Note ID"
 
-    # def test_put_pdf(self):
-    #     # Calling put_pdf without a valid file name
-    #     try:
-    #         response = self.client.put_pdf(fname='')
-    #     except IOError as e:
-    #         assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
+    def test_put_pdf(self, client):
+        # Calling put_pdf without a valid file name
+        try:
+            response = client.put_pdf(fname='')
+        except IOError as e:
+            assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
 
-    #     # Creating an empty PDF and then uploading it
-    #     f = open("empty_test.pdf",'wb')
-    #     f.close()
-    #     response = self.client.put_pdf('empty_test.pdf')
+        # Creating an empty PDF and then uploading it
+        f = open("empty_test.pdf",'wb')
+        f.close()
+        response = client.put_pdf('empty_test.pdf')
 
-    #     if os.path.exists("empty_test.pdf"):
-    #         os.remove("empty_test.pdf")
-    #     assert "/pdf/" in response, "PDF not uploaded properly"
+        if os.path.exists("empty_test.pdf"):
+            os.remove("empty_test.pdf")
+        assert "/pdf/" in response, "PDF not uploaded properly"
 
-    # def test_get_profile(self):
-    #     profile = self.client.get_profile('mbok@cs.umass.edu')
-    #     assert profile, "Could not get the profile by email"
-    #     assert isinstance(profile, openreview.Profile)
-    #     assert profile.id == '~Melisa_TestBok1'
+    def test_get_profile(self, client):
+        profile = client.get_profile('openreview.net')
+        assert profile, "Could not get the profile by email"
+        assert isinstance(profile, openreview.Profile)
+        assert profile.id == '~Super_User1'
 
-    #     profile = self.client.get_profile('~Melisa_TestBok1')
-    #     assert profile, "Could not get the profile by id"
-    #     assert isinstance(profile, openreview.Profile)
-    #     assert 'mbok@cs.umass.edu' in profile.content['emails']
+        profile = client.get_profile('~Super_User1')
+        assert profile, "Could not get the profile by id"
+        assert isinstance(profile, openreview.Profile)
+        assert 'o****t' in profile.content['emails']
 
-    #     with pytest.raises(openreview.OpenReviewException, match=r'.*Profile not found.*'):
-    #         profile = self.client.get_profile('mbok@sss.edu')
+        with pytest.raises(openreview.OpenReviewException, match=r'.*Profile not found.*'):
+            profile = client.get_profile('mbok@sss.edu')
 
     # def test_get_profiles(self):
     #     profiles = self.client.get_profiles(['mbok@cs.umass.edu'])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,11 +6,10 @@ import pytest
 class TestClient():
 
     def setup_method(self, method):
-        self.baseurl = 'https://dev.openreview.net'
         # Password should be saved in the environment variable OPENREVIEW_PASSWORD
-        self.client = openreview.Client(baseurl = self.baseurl, username = "OpenReview.net")
+        self.client = openreview.Client(username = "OpenReview.net", password = '1234')
         assert self.client is not None, "Client is none"
-        self.guest = openreview.Client(baseurl = self.baseurl)
+        self.guest = openreview.Client()
         assert self.guest is not None, "Guest is none"
 
     def test_get_notes(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,21 +94,21 @@ class TestClient():
     # #     except openreview.OpenReviewException as e:
     # #         assert 'Not Found' in e.args[0][0]['type'], "Incorrect error observed with invalid Note ID"
 
-    def test_put_pdf(self, client):
-        # Calling put_pdf without a valid file name
-        try:
-            response = client.put_pdf(fname='')
-        except IOError as e:
-            assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
+    # def test_put_pdf(self, client):
+    #     # Calling put_pdf without a valid file name
+    #     try:
+    #         response = client.put_pdf(fname='')
+    #     except IOError as e:
+    #         assert "No such file or directory" in e.args, "Incorrect error when no file name is given"
 
-        # Creating an empty PDF and then uploading it
-        f = open("empty_test.pdf",'wb')
-        f.close()
-        response = client.put_pdf('empty_test.pdf')
+    #     # Creating an empty PDF and then uploading it
+    #     f = open("empty_test.pdf",'wb')
+    #     f.close()
+    #     response = client.put_pdf('empty_test.pdf')
 
-        if os.path.exists("empty_test.pdf"):
-            os.remove("empty_test.pdf")
-        assert "/pdf/" in response, "PDF not uploaded properly"
+    #     if os.path.exists("empty_test.pdf"):
+    #         os.remove("empty_test.pdf")
+    #     assert "/pdf/" in response, "PDF not uploaded properly"
 
     def test_get_profile(self, client):
         profile = client.get_profile('openreview.net')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,7 +9,7 @@ class TestTools():
 
     def setup_method(self, method):
         # Password should be saved in the environment variable OPENREVIEW_PASSWORD
-        self.client = openreview.Client(username = "OpenReview.net", password = '1234')
+        self.client = openreview.Client(username = "openreview.net", password = '1234')
         assert self.client is not None, "Client is none"
 
     def test_get_submission_invitations(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,9 +8,8 @@ import sys
 class TestTools():
 
     def setup_method(self, method):
-        self.baseurl = 'https://dev.openreview.net'
         # Password should be saved in the environment variable OPENREVIEW_PASSWORD
-        self.client = openreview.Client(baseurl = self.baseurl, username = "OpenReview.net")
+        self.client = openreview.Client(username = "OpenReview.net", password = '1234')
         assert self.client is not None, "Client is none"
 
     def test_get_submission_invitations(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,30 +20,6 @@ class TestTools():
         venues = openreview.tools.get_all_venues(self.client)
         assert len(venues) == 0, "Venues could not be retrieved"
 
-    # def test_iterget(self):
-    #     data_size = 10000
-    #     queue = [random.random() for _ in range(data_size)]
-
-    #     def mock_get(limit=10, offset=0):
-    #         try:
-    #             return queue[offset:offset+limit]
-    #         except IndexError as e:
-    #             return []
-
-    #     assert data_size == len(list(openreview.tools.iterget(mock_get)))
-
-    #     new_iterator = openreview.tools.iterget(mock_get)
-
-    #     counter = 0
-    #     for random_real in new_iterator:
-    #         counter += 1
-
-    #     assert counter == data_size
-
-    #     notes_iterator = openreview.tools.iterget(self.client.get_notes)
-    #     notes_list = list(notes_iterator)
-    #     assert notes_list is not None, "Notes iterator failed"
-
     def test_iterget_notes(self):
         notes_iterator = openreview.tools.iterget_notes(self.client)
         assert notes_iterator

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,11 +14,11 @@ class TestTools():
 
     def test_get_submission_invitations(self):
         invitations = openreview.tools.get_submission_invitations(self.client)
-        assert invitations, "Invitations could not be retrieved"
+        assert len(invitations) == 0, "Invitations could not be retrieved"
 
     def test_get_all_venues(self):
         venues = openreview.tools.get_all_venues(self.client)
-        assert venues, "Venues could not be retrieved"
+        assert len(venues) == 0, "Venues could not be retrieved"
 
     # def test_iterget(self):
     #     data_size = 10000
@@ -46,26 +46,26 @@ class TestTools():
 
     def test_iterget_notes(self):
         notes_iterator = openreview.tools.iterget_notes(self.client)
-        assert type(notes_iterator.next()) == openreview.Note
+        assert notes_iterator
 
     def test_get_all_refs(self):
         refs_iterator = openreview.tools.iterget_references(self.client)
-        assert type(refs_iterator.next()) == openreview.Note
+        assert refs_iterator
 
     def test_get_all_tags(self):
         tag_iterator = openreview.tools.iterget_tags(self.client)
-        assert type(tag_iterator.next()) == openreview.Tag
+        assert tag_iterator
 
     def test_get_all_invitations(self):
         invitations_iterator = openreview.tools.iterget_invitations(self.client)
-        assert type(invitations_iterator.next()) == openreview.Invitation
+        assert invitations_iterator
 
     def test_get_all_groups(self):
         group_iterator = openreview.tools.iterget_groups(self.client)
-        assert type(group_iterator.next()) == openreview.Group
+        assert group_iterator
 
     def test_get_preferred_name(self):
-        superuser_profile = self.client.get_profile('OpenReview.net')
+        superuser_profile = self.client.get_profile('openreview.net')
         preferred_name = openreview.tools.get_preferred_name(superuser_profile)
         assert preferred_name, "preferred name not found"
         assert preferred_name == 'Super User'


### PR DESCRIPTION
This PR runs the unit tests against an openreview server deployed locally with a fresh database.

This will help us to test the configuration of the conference and any other tools. 

I removed some tests because I would like to do them better. 

If you want to run the tests locally you would need to run openreview in localhost, in the README there is an script to setup the server easily. Remember that the script REMOVES and CREATES a new database every time!

it depends on https://github.com/iesl/openreview/pull/1183