### PR TITLE
Fix/comment process function

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -163,7 +163,7 @@ class Conference(object):
         if public:
             self.invitation_builder.set_public_comment_invitation(self.id, notes_iterator, name, anonymous)
         else:
-            self.invitation_builder.set_private_comment_invitation(self.id, notes_iterator, name, anonymous)
+            self.invitation_builder.set_private_comment_invitation(self, notes_iterator, name, anonymous)
 
     # def close_comments():
     #     ## disable comments removing the invitees? or setting an expiration date

--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -3,56 +3,42 @@ function(){
 
     var CONFERENCE_ID = '';
     var SHORT_PHRASE = '';
+    var AUTHORS_NAME = '';
+    var REVIEWERS_NAME = '';
+    var AREA_CHAIRS_NAME = '';
+    var PROGRAM_CHAIRS_NAME = '';
 
-    var forumNoteP = or3client.or3request(or3client.notesUrl + '?id=' + note.forum, {}, 'GET', token);
-    var replytoNoteP = note.replyto ? or3client.or3request(or3client.notesUrl + '?id=' + note.replyto, {}, 'GET', token) : null;
+    or3client.or3request(or3client.notesUrl + '?id=' + note.forum, {}, 'GET', token)
+    .then(function(result) {
 
-    var checkReadersMatch = function(regex) {
-      for(reader of note.readers){
-        if(reader.match(regex)){
-          return true;
-        }
-      }
-      return false;
-    };
+      var forumNote = result.notes[0];
 
-    Promise.all([
-      forumNoteP,
-      replytoNoteP
-    ]).then(function(result) {
-
-      var forumNote = result[0].notes[0];
-      var replytoNote = note.replyto ? result[1].notes[0] : null;
-      var replytoNoteSignatures = replytoNote ? replytoNote.signatures : [];
-
-      var PAPER_AUTHORS = CONFERENCE_ID + '/Paper' + forumNote.number + '/Authors';
-      var PAPER_REVIEWERS = CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers';
-      var PAPER_AREACHAIRS = CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs';
-      var PROGRAM_CHAIRS = CONFERENCE_ID + '/Program_Chairs';
-
-      var author_mail;
+      var PAPER_AUTHORS = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + AUTHORS_NAME;
+      var PAPER_REVIEWERS = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + REVIEWERS_NAME;
+      var PAPER_AREACHAIRS = CONFERENCE_ID + '/Paper' + forumNote.number + '/' + AREA_CHAIRS_NAME;
+      var PROGRAM_CHAIRS = CONFERENCE_ID + '/' + PROGRAM_CHAIRS_NAME;
 
       var ac_mail = {
-        'groups': [CONFERENCE_ID + '/Paper' + forumNote.number + '/Area_Chairs'],
+        'groups': [PAPER_AREACHAIRS],
         'subject': '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
         'message': 'A comment was posted to a paper for which you are serving as Area Chair.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var reviewer_mail = {
-        'groups': [CONFERENCE_ID + '/Paper' + forumNote.number + '/Reviewers'],
+        'groups': [PAPER_REVIEWERS],
         'subject': '[' + SHORT_PHRASE + '] Comment posted to a paper you are reviewing. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
         'message': 'A comment was posted to a paper for which you are serving as reviewer.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var pc_mail = {
-        'groups': [CONFERENCE_ID + '/Program_Chairs'],
-        'subject': '[' + SHORT_PHRASE + '] A Program Chair-only comment was posted. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
-        'message': 'A comment was posted to a paper with readership restricted to only the Program Chairs.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+        'groups': [PROGRAM_CHAIRS],
+        'subject': '[' + SHORT_PHRASE + '] A comment was posted. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
+        'message': 'A comment was posted to a paper with readership restricted to the Program Chairs.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
-      author_mail = {
+      var author_mail = {
         'groups': forumNote.content.authorids,
-        'subject': '[' + SHORT_PHRASE + '] Your submission to ' + SHORT_PHRASE + ' has received a comment. Paper Title: \"' + forumNote.content.title + '\"',
+        'subject': '[' + SHORT_PHRASE + '] Your submission has received a comment. Paper Title: \"' + forumNote.content.title + '\"',
         'message': 'Your submission to ' + SHORT_PHRASE + ' has received a comment.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
@@ -70,16 +56,10 @@ function(){
         promises.push(or3client.or3request(or3client.mailUrl, ac_mail, 'POST', token));
       }
 
-      // This rule arbitrarily invented by Michael.
-      // Sends a message to Program Chairs only if the message is readable by only PCs,
-      // or only ACs and PCs. This will prevent the PCs from being constantly spammed.
-      if(note.readers.includes(PROGRAM_CHAIRS) &&
-        !note.readers.includes(PAPER_AREACHAIRS) &&
-        !note.readers.includes('everyone') &&
-        !note.readers.includes(PAPER_REVIEWERS)
-        ){
+      if(note.readers.includes(PROGRAM_CHAIRS) || note.readers.includes('everyone')){
         promises.push(or3client.or3request(or3client.mailUrl, pc_mail, 'POST', token));
       }
+
 
       return Promise.all(promises);
     })

--- a/openreview/conference/templates/commentProcess.js
+++ b/openreview/conference/templates/commentProcess.js
@@ -19,27 +19,31 @@ function(){
       var PROGRAM_CHAIRS = CONFERENCE_ID + '/' + PROGRAM_CHAIRS_NAME;
 
       var ac_mail = {
-        'groups': [PAPER_AREACHAIRS],
-        'subject': '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
-        'message': 'A comment was posted to a paper for which you are serving as Area Chair.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+        groups: [PAPER_AREACHAIRS],
+        ignoreGroups: [note.tauthor],
+        subject: '[' + SHORT_PHRASE + '] Comment posted to a paper in your area. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
+        message: 'A comment was posted to a paper for which you are serving as Area Chair.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var reviewer_mail = {
-        'groups': [PAPER_REVIEWERS],
-        'subject': '[' + SHORT_PHRASE + '] Comment posted to a paper you are reviewing. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
-        'message': 'A comment was posted to a paper for which you are serving as reviewer.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+        groups: [PAPER_REVIEWERS],
+        ignoreGroups: [note.tauthor],
+        subject: '[' + SHORT_PHRASE + '] Comment posted to a paper you are reviewing. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
+        message: 'A comment was posted to a paper for which you are serving as reviewer.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var pc_mail = {
-        'groups': [PROGRAM_CHAIRS],
-        'subject': '[' + SHORT_PHRASE + '] A comment was posted. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
-        'message': 'A comment was posted to a paper with readership restricted to the Program Chairs.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+        groups: [PROGRAM_CHAIRS],
+        ignoreGroups: [note.tauthor],
+        subject: '[' + SHORT_PHRASE + '] A comment was posted. Paper Number: ' + forumNote.number + ', Paper Title: \"' + forumNote.content.title + '\"',
+        message: 'A comment was posted to a paper with readership restricted to the Program Chairs.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var author_mail = {
-        'groups': forumNote.content.authorids,
-        'subject': '[' + SHORT_PHRASE + '] Your submission has received a comment. Paper Title: \"' + forumNote.content.title + '\"',
-        'message': 'Your submission to ' + SHORT_PHRASE + ' has received a comment.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
+        groups: forumNote.content.authorids,
+        ignoreGroups: [note.tauthor],
+        subject: '[' + SHORT_PHRASE + '] Your submission has received a comment. Paper Title: \"' + forumNote.content.title + '\"',
+        message: 'Your submission to ' + SHORT_PHRASE + ' has received a comment.\n\nComment title: ' + note.content.title + '\n\nComment: ' + note.content.comment + '\n\nTo view the comment, click here: ' + baseUrl + '/forum?id=' + note.forum + '&noteId=' + note.id
       };
 
       var promises = [];

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -145,8 +145,8 @@ class TestClient():
             content = {
                 'title': 'Paper title',
                 'abstract': 'This is an abstract',
-                'authorids': ['test@mail.com', 'mbok@mail.com', 'andrew@mail.com'],
-                'authors': ['Test User', 'Melisa Bok', 'Andrew Mc'],
+                'authorids': ['mbok@mail.com', 'andrew@mail.com'],
+                'authors': ['Melisa Bok', 'Andrew Mc'],
                 'pdf': '/pdf/22234qweoiuweroi.pdf'
             }
         )

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -1,0 +1,88 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import openreview
+import pytest
+import requests
+import datetime
+import os
+import re
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException
+
+class TestCommentNotification():
+
+    def test_notify_all(self, client, test_client):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+
+        builder.set_conference_id('MIDL.io/2019/Conference')
+        builder.set_conference_name('Medical Imaging with Deep Learning')
+        builder.set_conference_short_name('MIDL 2019')
+        builder.set_homepage_header({
+        'title': 'Medical Imaging with Deep Learning',
+        'subtitle': 'MIDL 2019 Conference',
+        'deadline': 'Submission Deadline: 13th of December, 2018',
+        'date': '8-10 July 2019',
+        'website': 'http://2019.midl.io',
+        'location': 'London',
+        'instructions': 'Full papers contain well-validated applications or methodological developments of deep learning algorithms in medical imaging. There is no strict limit on paper length. However, we strongly recommend keeping full papers at 8 pages (excluding references and acknowledgements). An appendix section can be added if needed with additional details but must be compiled into a single pdf. The appropriateness of using pages over the recommended page length will be judged by reviewers. All accepted papers will be presented as posters with a selection of these papers will also be invited for oral presentation.<br/><br/> <p><strong>Questions or Concerns</strong></p><p>Please contact the OpenReview support team at <a href=\"mailto:info@openreview.net\">info@openreview.net</a> with any questions or concerns about the OpenReview platform.<br/>    Please contact the MIDL 2019 Program Chairs at <a href=\"mailto:program-chairs@midl.io\">program-chairs@midl.io</a> with any questions or concerns about conference administration or policy.</p><p>We are aware that some email providers inadequately filter emails coming from openreview.net as spam so please check your spam folder regularly.</p>'
+        })
+        builder.set_conference_submission_name('Full_Submission')
+        conference = builder.get_result()
+
+        invitation = conference.open_submissions(due_date = datetime.datetime(2018, 12, 14, 8, 00), public = True)
+
+        note = openreview.Note(invitation = invitation.id,
+            readers = ['everyone'],
+            writers = ['~Test_User1', 'mbok@mail.com', 'andrew@mail.com'],
+            signatures = ['~Test_User1'],
+            content = {
+                'title': 'Paper title',
+                'abstract': 'This is an abstract',
+                'authorids': ['test@mail.com', 'mbok@mail.com', 'andrew@mail.com'],
+                'authors': ['Test User', 'Melisa Bok', 'Andrew Mc'],
+                'pdf': '/pdf/sdfskdls.pdf'
+            }
+        )
+
+        note = test_client.post_note(note)
+        assert note
+
+        conference.close_submissions(freeze_submissions = True)
+
+        conference.set_authors()
+        conference.open_comments(name = 'Official_Comment', public = False, anonymous = True)
+
+        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
+        authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = note.number)
+        reviewers_group_id = '{conference_id}/Paper{number}/Reviewers'.format(conference_id = conference.id, number = note.number)
+        anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = note.number)
+        acs_group_id = '{conference_id}/Paper{number}/Area_Chairs'.format(conference_id = conference.id, number = note.number)
+
+        openreview.tools.add_assignment(client, note.number, conference.id, 'reviewer@midl.io')
+        openreview.tools.add_assignment(client, note.number, conference.id, 'areachair@midl.io', individual_label='Area_Chair', parent_label='Area_Chairs')
+
+        comment_note = openreview.Note(invitation = comment_invitation_id,
+            forum = note.id,
+            replyto = note.id,
+            readers = [authors_group_id, reviewers_group_id, acs_group_id, conference.get_program_chairs_id()],
+            writers = [conference.id, 'reviewer@midl.io'],
+            signatures = [anon_reviewers_group_id],
+            content = {
+                'title': 'Comment title',
+                'comment': 'This is an comment'
+            }
+        )
+        comment_note = client.post_note(comment_note)
+
+        assert comment_note
+        assert comment_note.forum == note.id
+
+        response = client.get_messages(to = 'mbok@mail.com')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -127,7 +127,7 @@ class TestCommentNotification():
             }
         )
 
-        reply_comment_note = client.post_note(reply_comment_note)
+        reply_comment_note = test_client.post_note(reply_comment_note)
 
         response = client.get_messages(to = 'author@mail.com')
         assert response
@@ -138,11 +138,10 @@ class TestCommentNotification():
 
         response = client.get_messages(to = 'test@mail.com')
         assert response
-        assert len(response['messages']) == 4
+        assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
         assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
         assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
-        assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
         response = client.get_messages(to = 'author2@mail.com')
         assert response
@@ -190,11 +189,10 @@ class TestCommentNotification():
 
         response = client.get_messages(to = 'test@mail.com')
         assert response
-        assert len(response['messages']) == 4
+        assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
         assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
         assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
-        assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
         response = client.get_messages(to = 'author2@mail.com')
         assert response
@@ -220,3 +218,78 @@ class TestCommentNotification():
         assert len(response['messages']) == 2
         assert response['messages'][0]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
         assert response['messages'][1]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+
+        pc_client = openreview.Client(baseurl = 'http://localhost:3000')
+        assert pc_client is not None, "Client is none"
+        res = pc_client.register_user(email = 'programchair@midl.io', first = 'Program', last = 'Chair', password = '1234')
+        assert res, "Res i none"
+        res = pc_client.activate_user('programchair@midl.io', {
+            'names': [
+                    {
+                        'first': 'Program',
+                        'last': 'Chair',
+                        'username': '~Program_Chair1'
+                    }
+                ],
+            'emails': ['programchair@midl.io'],
+            'preferredEmail': 'programchair@midl.io'
+            })
+        assert res
+
+        reply3_comment_note = openreview.Note(invitation = comment_invitation_id,
+            forum = note.id,
+            replyto = comment_note.id,
+            readers = [reviewers_group_id, acs_group_id, conference.get_program_chairs_id()],
+            writers = [conference.id, 'programchair@midl.io'],
+            signatures = [conference.get_program_chairs_id()],
+            content = {
+                'title': 'Another reply to comment title',
+                'comment': 'This is a reply to the comment'
+            }
+        )
+
+        reply3_comment_note = pc_client.post_note(reply3_comment_note)
+
+        response = client.get_messages(to = 'author@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'test@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
+        assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'author2@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'reviewer@midl.io')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'areachair@midl.io')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'programchair@midl.io')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == 'OpenReview signup confirmation'
+
+

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -36,12 +36,12 @@ class TestCommentNotification():
 
         note = openreview.Note(invitation = invitation.id,
             readers = ['everyone'],
-            writers = ['~Test_User1', 'mbok@mail.com', 'andrew@mail.com'],
+            writers = ['~Test_User1', 'author@mail.com', 'andrew@mail.com'],
             signatures = ['~Test_User1'],
             content = {
                 'title': 'Paper title',
                 'abstract': 'This is an abstract',
-                'authorids': ['test@mail.com', 'mbok@mail.com', 'andrew@mail.com'],
+                'authorids': ['test@mail.com', 'author@mail.com', 'andrew@mail.com'],
                 'authors': ['Test User', 'Melisa Bok', 'Andrew Mc'],
                 'pdf': '/pdf/sdfskdls.pdf'
             }
@@ -81,7 +81,7 @@ class TestCommentNotification():
         assert comment_note
         assert comment_note.forum == note.id
 
-        response = client.get_messages(to = 'mbok@mail.com')
+        response = client.get_messages(to = 'author@mail.com')
         assert response
         assert len(response['messages']) == 2
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
@@ -129,7 +129,7 @@ class TestCommentNotification():
 
         reply_comment_note = client.post_note(reply_comment_note)
 
-        response = client.get_messages(to = 'mbok@mail.com')
+        response = client.get_messages(to = 'author@mail.com')
         assert response
         assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
@@ -181,7 +181,7 @@ class TestCommentNotification():
 
         reply2_comment_note = client.post_note(reply2_comment_note)
 
-        response = client.get_messages(to = 'mbok@mail.com')
+        response = client.get_messages(to = 'author@mail.com')
         assert response
         assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -36,12 +36,12 @@ class TestCommentNotification():
 
         note = openreview.Note(invitation = invitation.id,
             readers = ['everyone'],
-            writers = ['~Test_User1', 'author@mail.com', 'andrew@mail.com'],
+            writers = ['~Test_User1', 'author@mail.com', 'author2@mail.com'],
             signatures = ['~Test_User1'],
             content = {
                 'title': 'Paper title',
                 'abstract': 'This is an abstract',
-                'authorids': ['test@mail.com', 'author@mail.com', 'andrew@mail.com'],
+                'authorids': ['test@mail.com', 'author@mail.com', 'author2@mail.com'],
                 'authors': ['Test User', 'Melisa Bok', 'Andrew Mc'],
                 'pdf': '/pdf/sdfskdls.pdf'
             }
@@ -94,7 +94,7 @@ class TestCommentNotification():
         assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
         assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
-        response = client.get_messages(to = 'andrew@mail.com')
+        response = client.get_messages(to = 'author2@mail.com')
         assert response
         assert len(response['messages']) == 2
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
@@ -144,7 +144,7 @@ class TestCommentNotification():
         assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
         assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
-        response = client.get_messages(to = 'andrew@mail.com')
+        response = client.get_messages(to = 'author2@mail.com')
         assert response
         assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
@@ -196,7 +196,7 @@ class TestCommentNotification():
         assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
         assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
-        response = client.get_messages(to = 'andrew@mail.com')
+        response = client.get_messages(to = 'author2@mail.com')
         assert response
         assert len(response['messages']) == 3
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -53,6 +53,7 @@ class TestCommentNotification():
         conference.close_submissions(freeze_submissions = True)
 
         conference.set_authors()
+        conference.set_program_chairs(emails= ['programchair@midl.io'])
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True)
 
         comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
@@ -86,3 +87,136 @@ class TestCommentNotification():
         assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
         assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
 
+        response = client.get_messages(to = 'test@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
+        assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'andrew@mail.com')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'reviewer@midl.io')
+        assert response
+        assert len(response['messages']) == 1
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'areachair@midl.io')
+        assert response
+        assert len(response['messages']) == 1
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'programchair@midl.io')
+        assert response
+        assert len(response['messages']) == 1
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+
+        reply_comment_note = openreview.Note(invitation = comment_invitation_id,
+            forum = note.id,
+            replyto = comment_note.id,
+            readers = [authors_group_id, conference.get_program_chairs_id()],
+            writers = [conference.id, 'test@mail.com'],
+            signatures = [authors_group_id],
+            content = {
+                'title': 'Reply to comment title',
+                'comment': 'This is a reply to the comment'
+            }
+        )
+
+        reply_comment_note = client.post_note(reply_comment_note)
+
+        response = client.get_messages(to = 'mbok@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'test@mail.com')
+        assert response
+        assert len(response['messages']) == 4
+        assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
+        assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'andrew@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'reviewer@midl.io')
+        assert response
+        assert len(response['messages']) == 1
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'areachair@midl.io')
+        assert response
+        assert len(response['messages']) == 1
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'programchair@midl.io')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+
+        reply2_comment_note = openreview.Note(invitation = comment_invitation_id,
+            forum = note.id,
+            replyto = comment_note.id,
+            readers = [reviewers_group_id, acs_group_id],
+            writers = [conference.id, 'reviewer@midl.io'],
+            signatures = [anon_reviewers_group_id],
+            content = {
+                'title': 'Another reply to comment title',
+                'comment': 'This is a reply to the comment'
+            }
+        )
+
+        reply2_comment_note = client.post_note(reply2_comment_note)
+
+        response = client.get_messages(to = 'mbok@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'test@mail.com')
+        assert response
+        assert len(response['messages']) == 4
+        assert response['messages'][0]['content']['subject'] == 'OpenReview signup confirmation'
+        assert response['messages'][1]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][3]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'andrew@mail.com')
+        assert response
+        assert len(response['messages']) == 3
+        assert response['messages'][0]['content']['subject'] == 'MIDL 2019 has received your submission titled Paper title'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+        assert response['messages'][2]['content']['subject'] == '[MIDL 2019] Your submission has received a comment. Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'reviewer@midl.io')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Comment posted to a paper you are reviewing. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'areachair@midl.io')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] Comment posted to a paper in your area. Paper Number: 1, Paper Title: "Paper title"'
+
+        response = client.get_messages(to = 'programchair@midl.io')
+        assert response
+        assert len(response['messages']) == 2
+        assert response['messages'][0]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'
+        assert response['messages'][1]['content']['subject'] == '[MIDL 2019] A comment was posted. Paper Number: 1, Paper Title: "Paper title"'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 2, "Invitations could not be retrieved"
+        assert len(invitations) == 3, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) == 4, "Venues could not be retrieved"
+        assert len(venues) == 5, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)


### PR DESCRIPTION
- Customize comment process function based on Conference configuration names.
- Send emails to all the readers of the note except the tauthor: it depends on https://github.com/iesl/openreview/pull/1262
- Clean comment process function code.
- Add email notification tests.