### PR TITLE
add command-line executable option to replace_members_with_ids

### DIFF
--- a/openreview/__init__.py
+++ b/openreview/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
 from .openreview import *
-from . import tools
+from .tools import *
 from . import invitations
 from .conference import *

--- a/openreview/tools/__init__.py
+++ b/openreview/tools/__init__.py
@@ -1,0 +1,1 @@
+from .tools import *

--- a/openreview/tools/replace_members_with_ids.py
+++ b/openreview/tools/replace_members_with_ids.py
@@ -1,0 +1,44 @@
+import openreview
+import argparse
+
+def replace_members_with_ids(client, group):
+    '''
+    Given a Group object, iterates through the Group's members and, for any member
+    represented by an email address, attempts to find a profile associated with
+    that email address. If a profile is found, replaces the email with the profile ID.
+
+    Returns None.
+    '''
+    ids = []
+    emails = []
+    for member in group.members:
+        if '~' not in member:
+            try:
+                profile = client.get_profile(member.lower())
+                ids.append(profile.id)
+            except openreview.OpenReviewException as e:
+                if 'Profile not found' in e.args[0][0]:
+                    emails.append(member.lower())
+                else:
+                    raise e
+        else:
+            ids.append(member)
+
+    group.members = ids + emails
+    return client.post_group(group)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('group_id', help='group ID whose members should be written to the name file')
+    parser.add_argument('--baseurl', help="base url")
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+    args = parser.parse_args()
+
+    client = openreview.Client(baseurl=args.baseurl, username=args.username, password=args.password)
+
+    target_group = client.get_group(args.group_id)
+    posted_group = replace_members_with_ids(client, target_group)
+
+    print(posted_group)
+

--- a/openreview/tools/tools.py
+++ b/openreview/tools/tools.py
@@ -371,32 +371,6 @@ def get_paperhash(first_author, title):
     first_author = re.sub(strip_punctuation, '', first_author)
     return (first_author + '|' + title).lower()
 
-def replace_members_with_ids(client, group):
-    '''
-    Given a Group object, iterates through the Group's members and, for any member
-    represented by an email address, attempts to find a profile associated with
-    that email address. If a profile is found, replaces the email with the profile ID.
-
-    Returns None.
-    '''
-    ids = []
-    emails = []
-    for member in group.members:
-        if '~' not in member:
-            try:
-                profile = client.get_profile(member.lower())
-                ids.append(profile.id)
-            except openreview.OpenReviewException as e:
-                if 'Profile not found' in e.args[0][0]:
-                    emails.append(member.lower())
-                else:
-                    raise e
-        else:
-            ids.append(member)
-
-    group.members = ids + emails
-    return client.post_group(group)
-
 class iterget:
     def __init__(self, get_function, **params):
         self.offset = 0


### PR DESCRIPTION
this lets us execute the function `replace_members_with_ids` directly from the command line, like so:

```python -m openreview.tools.replace_members_with_ids MIDL.io/2019/Conference/Reviewers/Accepted --baseurl https://openreview.net```

We could do this for other tools as well. I think it would be useful.