### PR TITLE
Fixed regex for authorids in submission forms

### DIFF
--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -143,7 +143,7 @@ submission = {
     'authorids': {
         'description': 'Comma separated list of author email addresses, lowercased, in the same order as above. For authors with existing OpenReview accounts, please make sure that the provided email address(es) match those listed in the author\'s profile.',
         'order': 3,
-        'values-regex': "([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{2,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})",
+        'values-regex': "([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,},){0,}([a-z0-9_\-\.]{1,}@[a-z0-9_\-\.]{2,}\.[a-z]{2,})",
         'required':True
     },
     'keywords': {

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -863,7 +863,7 @@ def assign(client, paper_number, conference,
     use_profile = True):
 
     '''
-    DEPRECATED as of openreveiew-py revision 0.9.5
+    DEPRECATED as of openreview-py revision 0.9.5
 
     Either assigns or unassigns a reviewer to a paper.
     TODO: Is this function really necessary?

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 3, "Invitations could not be retrieved"
+        assert len(invitations) > 0, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) == 5, "Venues could not be retrieved"
+        assert len(venues) > 0, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) > 0, "Invitations could not be retrieved"
+        assert len(invitations) == 3, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) > 0, "Venues could not be retrieved"
+        assert len(venues) == 5, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)


### PR DESCRIPTION
This allows author emails to have a single character before the '@' symbol. e.g. m@umass.edu would be acceptable with this modification in the regex.