### PR TITLE
Fix/iterget and details improvements

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -434,6 +434,8 @@ class Client(object):
             params['mintcdate'] = mintcdate
         if details != None:
             params['details'] = details
+        else:
+            params['noDetails'] = True
 
         response = requests.get(self.notes_url, params = params, headers = self.headers)
         response = self.__handle_response(response)

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -407,9 +407,11 @@ class iterget:
 
         self.params = params
         self.params.update({
-            'offset': self.offset,
-            'limit': 1000
+            'offset': self.offset
         })
+
+        if 'limit' not in self.params:
+            self.params['limit'] = 1000
 
         self.get_function = get_function
         self.current_batch = self.get_function(**self.params)
@@ -475,7 +477,8 @@ def iterget_notes(client,
         number = None,
         mintcdate = None,
         content = None,
-        details = None):
+        details = None,
+        limit = None):
     '''
     Returns an iterator over Notes, filtered by the provided parameters, ignoring API limit.
 
@@ -526,6 +529,8 @@ def iterget_notes(client,
         params['content'] = content
     if details != None:
         params['details'] = details
+    if limit != None:
+        params['limit'] = limit
 
     return iterget(client.get_notes, **params)
 


### PR DESCRIPTION
some small improvements I made over the weekend.

1. if "details" param isn't provided, default to noDetails=True
2. allow the caller of iterget_notes to set a limit on the batch size