### PR TITLE
Fix/set assignments

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -70,6 +70,9 @@ class Conference(object):
         if bid_invitation:
             return self.webfield_builder.set_bid_page(self, bid_invitation)
 
+    def __set_recommendation_page(self):
+        return True
+
     def set_id(self, id):
         self.id = id
 
@@ -312,6 +315,13 @@ class Conference(object):
         invitation.invitees = []
         return self.client.post_invitation(invitation)
 
+    def open_recommendations(self, due_date, reviewer_assingment_title):
+        notes_iterator = self.get_submissions()
+        assingment_notes_iterator = tools.iterget_notes(self.client, invitation = self.id + '/-/Paper_Assignment', content = { 'title': reviewer_assingment_title })
+        self.invitation_builder.set_recommendation_invitation(self, due_date, notes_iterator, assingment_notes_iterator)
+        return self.__set_recommendation_page()
+
+
     def open_comments(self, name, public, anonymous):
         ## Create comment invitations per paper
         notes_iterator = self.get_submissions()
@@ -377,8 +387,8 @@ class Conference(object):
             self.__create_group('{number_group}/{author_name}'.format(number_group = group.id, author_name = self.authors_name), self.id, authorids)
 
     def setup_matching(self):
-        conference_matching = matching.Matching()
-        return conference_matching.setup(self)
+        conference_matching = matching.Matching(self)
+        return conference_matching.setup()
 
     def set_assignment(self, user, number, is_area_chair = False):
 
@@ -415,6 +425,10 @@ class Conference(object):
                     self.get_area_chairs_id(number = number)
                 ]
             })
+
+    def set_assignments(self, assingment_title):
+        conference_matching = matching.Matching(self)
+        return conference_matching.deploy(assingment_title)
 
     def recruit_reviewers(self, emails = [], title = None, message = None, reviewers_name = 'Reviewers', reviewer_accepted_name = None, remind = False):
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -70,8 +70,10 @@ class Conference(object):
         if bid_invitation:
             return self.webfield_builder.set_bid_page(self, bid_invitation, subject_areas)
 
-    def __set_recommendation_page(self):
-        return True
+    def __set_recommendation_page(self, subject_areas):
+        recommendation_invitation = self.client.get_invitation(self.get_id() + '/-/Recommendation')
+        if recommendation_invitation:
+            return self.webfield_builder.set_recommendation_page(self, recommendation_invitation, subject_areas)
 
     def set_id(self, id):
         self.id = id
@@ -315,11 +317,11 @@ class Conference(object):
         invitation.invitees = []
         return self.client.post_invitation(invitation)
 
-    def open_recommendations(self, due_date, reviewer_assingment_title):
+    def open_recommendations(self, due_date, reviewer_assingment_title, subject_areas = []):
         notes_iterator = self.get_submissions()
         assingment_notes_iterator = tools.iterget_notes(self.client, invitation = self.id + '/-/Paper_Assignment', content = { 'title': reviewer_assingment_title })
         self.invitation_builder.set_recommendation_invitation(self, due_date, notes_iterator, assingment_notes_iterator)
-        return self.__set_recommendation_page()
+        return self.__set_recommendation_page(subject_areas)
 
 
     def open_comments(self, name, public, anonymous):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -324,7 +324,7 @@ class Conference(object):
         invitation.invitees = []
         return self.client.post_invitation(invitation)
 
-    def open_recommendations(self, due_date, reviewer_assingment_title]):
+    def open_recommendations(self, due_date, reviewer_assingment_title):
         notes_iterator = self.get_submissions()
         assingment_notes_iterator = tools.iterget_notes(self.client, invitation = self.id + '/-/Paper_Assignment', content = { 'title': reviewer_assingment_title })
         self.invitation_builder.set_recommendation_invitation(self, due_date, notes_iterator, assingment_notes_iterator)

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -531,7 +531,7 @@ class InvitationBuilder(object):
             invitees = [],
             writers = [conference.get_id()],
             signatures = [conference.get_id()],
-            multiReply = False,
+            multiReply = True,
             reply = {
                 'invitation': conference.get_blind_submission_id(),
                 'readers': {
@@ -561,13 +561,13 @@ class InvitationBuilder(object):
             assignment_note = assignment_note_by_forum.get(note.id)
             if assignment_note:
                 for group in assignment_note['assignedGroups']:
-                    reviewers.append('{profileId}/Assigned/Bid_{bid}/Tpms:{tpms}'.format(
+                    reviewers.append('{profileId} (A) - Bid: {bid} - Tpms: {tpms}'.format(
                         profileId = group.get('userId'),
                         bid = group.get('scores').get('bid'),
                         tpms = group.get('scores').get('affinity'))
                     )
                 for group in assignment_note['alternateGroups']:
-                    reviewers.append('{profileId}/Alternate/Bid_{bid}/Tpms:{tpms}'.format(
+                    reviewers.append('{profileId} - Bid: {bid} - Tpms: {tpms}'.format(
                         profileId = group.get('userId'),
                         bid = group.get('scores').get('bid'),
                         tpms = group.get('scores').get('affinity'))
@@ -580,7 +580,7 @@ class InvitationBuilder(object):
                 invitees = [conference.get_program_chairs_id(), conference.get_id() + '/Paper{number}/Area_Chairs'.format(number = note.number)],
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],
-                multiReply = False,
+                multiReply = True,
                 reply = {
                     'forum': note.id,
                     'content': {

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -561,13 +561,13 @@ class InvitationBuilder(object):
             assignment_note = assignment_note_by_forum.get(note.id)
             if assignment_note:
                 for group in assignment_note['assignedGroups']:
-                    reviewers.append('{profileId} (Assigned) - Bid: {bid} - Tpms: {tpms}'.format(
+                    reviewers.append('{profileId}/Assigned/Bid_{bid}/Tpms:{tpms}'.format(
                         profileId = group.get('userId'),
                         bid = group.get('scores').get('bid'),
                         tpms = group.get('scores').get('affinity'))
                     )
                 for group in assignment_note['alternateGroups']:
-                    reviewers.append('{profileId} (Alternate) - Bid: {bid} - Tpms: {tpms}'.format(
+                    reviewers.append('{profileId}/Alternate/Bid_{bid}/Tpms:{tpms}'.format(
                         profileId = group.get('userId'),
                         bid = group.get('scores').get('bid'),
                         tpms = group.get('scores').get('affinity'))

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -3,6 +3,9 @@ from collections import defaultdict
 
 class Matching(object):
 
+    def __init__(self, conference):
+        self.conference = conference
+
     def clear(self, client, invitation):
         note_list = list(openreview.tools.iterget_notes(client, invitation = invitation))
         for note in note_list:
@@ -99,9 +102,40 @@ class Matching(object):
 
         return client.post_note(new_metadata_note)
 
+    def get_assignments(self, config_note, submissions, assignment_notes):
+        assignments = []
 
-    def setup(self, conference):
+        paper_by_forum = { n.forum: n for n in submissions }
 
+        added_constraints = config_note.content.get('constraints', {})
+
+        for assignment in assignment_notes:
+            assigned_groups = assignment.content['assignedGroups']
+            paper_constraints = added_constraints.get(assignment.forum, {})
+            paper_assigned = []
+            for assignment_entry in assigned_groups:
+                score = assignment_entry.get('finalScore', 0)
+                user_id = assignment_entry['userId']
+                paper_assigned.append(user_id)
+
+                paper = paper_by_forum.get(assignment.forum)
+
+                if paper and paper_constraints.get(user_id) != '-inf':
+                    current_row = [paper.number, paper.forum, user_id, score]
+                    assignments.append(current_row)
+
+            for user, constraint in paper_constraints.items():
+                print('user, constraint', user, constraint)
+                if user not in paper_assigned and constraint == '+inf':
+                    current_row = [paper.number, paper.forum, user, constraint]
+                    assignments.append(current_row)
+
+
+        return sorted(assignments, key=lambda x: x[0])
+
+    def setup(self):
+
+        conference = self.conference
         client = conference.client
         CONFERENCE_ID = conference.get_id()
         PROGRAM_CHAIRS_ID = conference.get_program_chairs_id()
@@ -312,6 +346,63 @@ class Matching(object):
         for note in submissions:
             scores_by_reviewer = scores_by_reviewer_by_paper[note.id]
             self.post_metadata_note(client, note, user_profiles, metadata_inv, scores_by_reviewer, {})
+
+
+    def deploy(self, assingment_title):
+
+        # Get the configuration note to check the group to assign
+        client = self.conference.client
+        notes = client.get_notes(invitation = self.conference.get_id() + '/-/Assignment_Configuration', content = { 'title': assingment_title })
+
+        if notes:
+            configuration_note = notes[0]
+            match_group = configuration_note.content['match_group']
+            is_area_chair = self.conference.get_area_chairs_id() == match_group
+            submissions = openreview.tools.iterget_notes(client, invitation = self.conference.get_blind_submission_id())
+            assignment_notes = openreview.tools.iterget_notes(client, invitation = self.conference.get_id() + '/-/Paper_Assignment', content = { 'title': assingment_title })
+
+
+            assignments = self.get_assignments(configuration_note, submissions, assignment_notes)
+
+            for a in assignments:
+                paper_number = a[0]
+                user = a[2]
+
+                if is_area_chair:
+                    parent_label = 'Area_Chairs'
+                    individual_label = 'Area_Chair'
+                    individual_group_params = {}
+                    parent_group_params = {}
+                else:
+                    parent_label = 'Reviewers'
+                    individual_label = 'AnonReviewer'
+                    individual_group_params = {
+                        'readers': [
+                            self.conference.get_id(),
+                            self.conference.get_program_chairs_id(),
+                            self.conference.get_area_chairs_id(number = paper_number)
+                        ],
+                    }
+                    parent_group_params = {
+                       'readers': [
+                            self.conference.get_id(),
+                            self.conference.get_program_chairs_id(),
+                            self.conference.get_area_chairs_id(number = paper_number)
+                        ]
+                    }
+
+                new_assigned_group = openreview.tools.add_assignment(
+                    client, paper_number, self.conference.get_id(), user,
+                    parent_label = parent_label,
+                    individual_label = individual_label,
+                    individual_group_params = individual_group_params,
+                    parent_group_params = parent_group_params)
+                print(new_assigned_group)
+
+
+        else:
+            raise openreview.OpenReviewException('Configuration not found for ' + assingment_title)
+
 
 
 

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -1,0 +1,150 @@
+// ------------------------------------
+// Recommendation Interface
+// ------------------------------------
+
+var CONFERENCE_ID = '';
+var HEADER = {};
+var BLIND_SUBMISSION_ID = '';
+var SUBJECT_AREAS = '';
+
+var AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Area_Chair.*';
+
+// Main is the entry point to the webfield code and runs everything
+function main() {
+  Webfield.ui.setup('#invitation-container', CONFERENCE_ID);  // required
+
+  Webfield.ui.header(HEADER.title, HEADER.instructions);
+
+  renderConferenceTabs();
+
+  Webfield.ui.spinner('#notes', { inline: true });
+
+  Webfield.get('/groups', {
+    member: user.id, regex: AREACHAIR_WILDCARD
+  })
+  .then(function(result) {
+    return getPaperNumbersfromGroups(result.groups);
+  })
+  .then(load)
+  .then(renderContent)
+  .then(Webfield.ui.done);
+}
+
+// Util functions
+var getNumberfromGroup = function(groupId, name) {
+
+  var tokens = groupId.split('/');
+  paper = _.find(tokens, function(token) { return token.startsWith(name); });
+  if (paper) {
+    return parseInt(paper.replace(name, ''));
+  } else {
+    return null;
+  }
+};
+
+var getPaperNumbersfromGroups = function(groups) {
+  return _.filter(_.map(groups, function(group) {
+    return getNumberfromGroup(group.id, 'Paper');
+  }), _.isInteger);
+};
+
+function renderConferenceTabs() {
+  var sections = [
+    {
+      heading: 'Your assigned papers',
+      id: 'all-submissions',
+    }
+  ];
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
+}
+
+
+// Perform all the required API calls
+function load(noteNumbers) {
+
+  var notesP = $.Deferred().resolve([]);
+
+  if (noteNumbers.length) {
+    var noteNumbersStr = noteNumbers.join(',');
+
+    notesP = Webfield.getAll('/notes', {invitation: BLIND_SUBMISSION_ID, number: noteNumbersStr, details: 'tags'}).then(function(allNotes) {
+      return allNotes.map(function(note) {
+        note.details.tags = note.details.tags.filter(function(tag) {
+          return tag.tauthor;
+        });
+        return note;
+      });
+    });
+  }
+
+  var tagInvitationsP = Webfield.getAll('/invitations', { regex: CONFERENCE_ID + '/-/Paper.*/Recommendation', tags: true, invitee: true });
+
+  return $.when(notesP, tagInvitationsP);
+}
+
+
+// Display the bid interface populated with loaded data
+function renderContent(notes, tagInvitations) {
+
+  $('#notes .tabs-container').remove();
+  var sections = [
+    {
+      heading: 'Your assigned papers',
+      id: 'all-submissions',
+    }
+  ];
+
+  Webfield.ui.tabPanel(sections, {
+    container: '#notes',
+    hidden: true
+  });
+
+  // All Submitted Papers tab
+  var submissionListOptions = {
+    pdfLink: true,
+    showContents: true,
+    showTags: true,
+    tagInvitations: tagInvitations,
+    container: '#all-submissions'
+  };
+
+  $(submissionListOptions.container).empty();
+
+  if (notes.length){
+    Webfield.ui.submissionList(notes, {
+      heading: null,
+      container: '#all-submissions',
+      search: {
+        enabled: true,
+        localSearch: true,
+        subjectAreas: SUBJECT_AREAS,
+        subjectAreaDropdown: 'basic',
+        onResults: function(searchResults) {
+          Webfield.ui.searchResults(searchResults, submissionListOptions);
+          Webfield.disableAutoLoading();
+        },
+        onReset: function() {
+          Webfield.ui.searchResults(notes, submissionListOptions);
+        }
+      },
+      displayOptions: submissionListOptions,
+      fadeIn: false
+    });
+
+  } else {
+    $('.tabs-container a[href="#all-submissions"]').parent().hide();
+  }
+
+
+  $('#notes > .spinner-container').remove();
+  $('#notes .tabs-container').show();
+
+  Webfield.ui.done();
+}
+
+// Go!
+main();

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -86,7 +86,7 @@ function renderContent(notes, tagInvitations) {
   // Set up tabs
   var sections = [{
     heading: 'Your Assigned Papers',
-    id: 'all-submissions',
+    id: 'your-assigned-submissions',
   }];
 
   Webfield.ui.tabPanel(sections, {
@@ -100,7 +100,7 @@ function renderContent(notes, tagInvitations) {
     showContents: true,
     showTags: true,
     tagInvitations: tagInvitations,
-    container: '#all-submissions'
+    container: '#your-assigned-submissions'
   };
 
   Webfield.ui.submissionList(notes, {

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -15,24 +15,54 @@ function main() {
 
   Webfield.ui.header(HEADER.title, HEADER.instructions);
 
-  renderConferenceTabs();
-
   Webfield.ui.spinner('#notes', { inline: true });
 
-  Webfield.get('/groups', {
-    member: user.id, regex: AREACHAIR_WILDCARD
-  })
-  .then(function(result) {
-    return getPaperNumbersfromGroups(result.groups);
-  })
-  .then(load)
-  .then(renderContent)
-  .then(Webfield.ui.done);
+  load().then(renderContent).then(Webfield.ui.done);
 }
 
-// Util functions
-var getNumberfromGroup = function(groupId, name) {
 
+// Perform all the required API calls
+function load() {
+  return Webfield.get('/groups', {
+    member: user.id, regex: AREACHAIR_WILDCARD
+  }).then(function(result) {
+    var noteNumbers = getPaperNumbersFromGroups(result.groups);
+
+    var notesP;
+    if (noteNumbers.length) {
+      var noteNumbersStr = noteNumbers.join(',');
+
+      notesP = Webfield.getAll('/notes', {
+        invitation: BLIND_SUBMISSION_ID, number: noteNumbersStr, details: 'tags'
+      }).then(function(allNotes) {
+        return allNotes.map(function(note) {
+          note.details.tags = note.details.tags.filter(function(tag) {
+            return tag.tauthor;
+          });
+          return note;
+        });
+      });
+    } else {
+      notesP = $.Deferred().resolve([]);
+    }
+
+    var tagInvitationsP = Webfield.getAll('/invitations', {
+      regex: CONFERENCE_ID + '/-/Paper.*/Recommendation', tags: true, invitee: true
+    });
+
+    return $.when(notesP, tagInvitationsP);
+  });
+}
+
+
+// Util functions
+function getPaperNumbersFromGroups(groups) {
+  return _.filter(_.map(groups, function(group) {
+    return getNumberFromGroup(group.id, 'Paper');
+  }), _.isInteger);
+}
+
+function getNumberFromGroup(groupId, name) {
   var tokens = groupId.split('/');
   paper = _.find(tokens, function(token) { return token.startsWith(name); });
   if (paper) {
@@ -40,70 +70,31 @@ var getNumberfromGroup = function(groupId, name) {
   } else {
     return null;
   }
-};
-
-var getPaperNumbersfromGroups = function(groups) {
-  return _.filter(_.map(groups, function(group) {
-    return getNumberfromGroup(group.id, 'Paper');
-  }), _.isInteger);
-};
-
-function renderConferenceTabs() {
-  var sections = [
-    {
-      heading: 'Your assigned papers',
-      id: 'all-submissions',
-    }
-  ];
-
-  Webfield.ui.tabPanel(sections, {
-    container: '#notes',
-    hidden: true
-  });
 }
 
 
-// Perform all the required API calls
-function load(noteNumbers) {
-
-  var notesP = $.Deferred().resolve([]);
-
-  if (noteNumbers.length) {
-    var noteNumbersStr = noteNumbers.join(',');
-
-    notesP = Webfield.getAll('/notes', {invitation: BLIND_SUBMISSION_ID, number: noteNumbersStr, details: 'tags'}).then(function(allNotes) {
-      return allNotes.map(function(note) {
-        note.details.tags = note.details.tags.filter(function(tag) {
-          return tag.tauthor;
-        });
-        return note;
-      });
-    });
-  }
-
-  var tagInvitationsP = Webfield.getAll('/invitations', { regex: CONFERENCE_ID + '/-/Paper.*/Recommendation', tags: true, invitee: true });
-
-  return $.when(notesP, tagInvitationsP);
-}
-
-
-// Display the bid interface populated with loaded data
+// Display the recommend interface populated with loaded data
 function renderContent(notes, tagInvitations) {
 
-  $('#notes .tabs-container').remove();
-  var sections = [
-    {
-      heading: 'Your assigned papers',
-      id: 'all-submissions',
-    }
-  ];
+  // Nothing to dispay
+  if (!notes.length) {
+    $('#notes').empty();
+    $('#notes').append('<p class="empty-message">You have no assigned papers at this time.</p>');
+    return;
+  }
+
+  // Set up tabs
+  var sections = [{
+    heading: 'Your Assigned Papers',
+    id: 'all-submissions',
+  }];
 
   Webfield.ui.tabPanel(sections, {
     container: '#notes',
     hidden: true
   });
 
-  // All Submitted Papers tab
+  // Your Assigned Papers tab
   var submissionListOptions = {
     pdfLink: true,
     showContents: true,
@@ -112,38 +103,29 @@ function renderContent(notes, tagInvitations) {
     container: '#all-submissions'
   };
 
-  $(submissionListOptions.container).empty();
-
-  if (notes.length){
-    Webfield.ui.submissionList(notes, {
-      heading: null,
-      container: '#all-submissions',
-      search: {
-        enabled: true,
-        localSearch: true,
-        subjectAreas: SUBJECT_AREAS,
-        subjectAreaDropdown: 'basic',
-        onResults: function(searchResults) {
-          Webfield.ui.searchResults(searchResults, submissionListOptions);
-          Webfield.disableAutoLoading();
-        },
-        onReset: function() {
-          Webfield.ui.searchResults(notes, submissionListOptions);
-        }
+  Webfield.ui.submissionList(notes, {
+    heading: null,
+    container: submissionListOptions.container,
+    search: {
+      enabled: true,
+      localSearch: true,
+      subjectAreas: SUBJECT_AREAS,
+      subjectAreaDropdown: 'basic',
+      onResults: function(searchResults) {
+        Webfield.ui.searchResults(searchResults, submissionListOptions);
+        Webfield.disableAutoLoading();
       },
-      displayOptions: submissionListOptions,
-      fadeIn: false
-    });
-
-  } else {
-    $('.tabs-container a[href="#all-submissions"]').parent().hide();
-  }
-
+      onReset: function() {
+        Webfield.ui.searchResults(notes, submissionListOptions);
+      }
+    },
+    displayOptions: submissionListOptions,
+    fadeIn: false
+  });
 
   $('#notes > .spinner-container').remove();
   $('#notes .tabs-container').show();
 
-  Webfield.ui.done();
 }
 
 // Go!

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -81,7 +81,7 @@ class WebfieldBuilder(object):
             group.web = content
             return self.client.post_group(group)
 
-    def set_bid_page(self, conference, invitation, subject_areas):
+    def set_bid_page(self, conference, invitation):
 
         default_header = {
             'title': conference.get_short_name() + ' Bidding Console',
@@ -115,12 +115,12 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
             content = content.replace("var BID_ID = '';", "var BID_ID = '" + conference.get_bid_id() + "';")
-            content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(subject_areas) + ";")
+            content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.get_subject_areas()) + ";")
 
             invitation.web = content
             return self.client.post_invitation(invitation)
 
-    def set_recommendation_page(self, conference, invitation, subject_areas):
+    def set_recommendation_page(self, conference, invitation):
 
         default_header = {
             'title': conference.get_short_name() + ' Reviewer Recommendation Console',
@@ -145,7 +145,7 @@ class WebfieldBuilder(object):
             content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
-            content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(subject_areas) + ";")
+            content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.get_subject_areas()) + ";")
 
             invitation.web = content
             return self.client.post_invitation(invitation)

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -120,6 +120,36 @@ class WebfieldBuilder(object):
             invitation.web = content
             return self.client.post_invitation(invitation)
 
+    def set_recommendation_page(self, conference, invitation, subject_areas):
+
+        default_header = {
+            'title': conference.get_short_name() + ' Reviewer Recommendation Console',
+            'instructions': '<p class="dark">Please select the reviewers you want to recommend for each paper.</p>\
+                <p class="dark"><strong>Please note:</strong></p>\
+                <ul>\
+                    <li>The list of reviewers for each papers are sorted by assignment score.</li>\
+                    <li>Assigned: reviewers assigned using the first macthing, Alternate: next possible reviewers to assign.</li>\
+                </ul>\
+                <p class="dark"><strong>A few tips:</strong></p>\
+                <ul>\
+                    <li>.</li>\
+                    <li>.</li>\
+                </ul>\
+                <br>'
+        }
+
+        header = self.__build_options(default_header, {})
+
+        with open(os.path.join(os.path.dirname(__file__), 'templates/recommendationWebfield.js')) as f:
+            content = f.read()
+            content = content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
+            content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
+            content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
+            content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(subject_areas) + ";")
+
+            invitation.web = content
+            return self.client.post_invitation(invitation)
+
     def set_recruit_page(self, conference_id, invitation, options = {}):
 
         default_header = {

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -273,8 +273,7 @@ class TestDoubleBlindConference():
             'schedule': 'This is the author schedule'
         })
         builder.set_double_blind(True)
-        conference = builder.get_result()
-        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00), subject_areas = ['Machine Learning',
+        builder.set_subject_areas(['Machine Learning',
             'Natural Language Processing',
             'Information Extraction',
             'Question Answering',
@@ -291,7 +290,9 @@ class TestDoubleBlindConference():
             'Fairness',
             'Human computation',
             'Crowd-sourcing',
-            'Other'], additional_fields = {
+            'Other'])
+        conference = builder.get_result()
+        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00), additional_fields = {
                 'archival_status': {
                     'description': 'Authors can change the archival/non-archival status up until the decision deadline',
                     'value-radio': [


### PR DESCRIPTION
- Deploy assignments into groups, reviewers or area chairs. (Copied from previous scripts)
- Create reviewer recommendation invitations based on the results of the first reviewer matching. 
- Create a recommendation webfield to make recommendations by areas chairs. @zbialecki please review. 
- Set subject areas array through the builder at the beginning. We don't need to pass the array every time we need to use it. 