### PR TITLE
Fix/readers refactor

### DIFF
--- a/docs/source/conference_builder.srt
+++ b/docs/source/conference_builder.srt
@@ -38,6 +38,8 @@ Set the properties that we need to start the conference
     >>>         </ul></p>',
     >>>     'deadline': 'Submission Deadline: Midnight Pacific Time, Friday, October 5, 2019'
     >>> })
+    >>> conference = builder.set_double_blind(True)
+    >>> conference = builder.set_submission_public(True)
     >>> conference = builder.get_result()
 
 this will setup the home page of the conference: https://opereview.net/group?id=AKBC.ws/2019/Conference

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -195,7 +195,6 @@ class Conference(object):
 
     def get_submission_readers(self):
         return [
-            self.get_program_chairs_id(),
             self.get_area_chairs_id(),
             self.get_reviewers_id()
         ]
@@ -304,10 +303,7 @@ class Conference(object):
             if self.submission_public:
                 posted_blind_note.readers = ['everyone']
             else:
-                posted_blind_note.readers = [
-                    self.get_program_chairs_id(),
-                    self.get_area_chairs_id(),
-                    self.get_reviewers_id(),
+                posted_blind_note.readers = self.get_submission_readers() + [
                     self.get_authors_id(number = posted_blind_note.number)
                 ]
 
@@ -606,18 +602,14 @@ class ConferenceBuilder(object):
     def set_override_homepage(self, override):
         self.override_homepage = override
 
-    def set_double_blind(self, double_blind):
+    def set_double_blind(self, double_blind = True, reviewers_read_original = False, area_chairs_read_original = False):
         self.conference.set_double_blind(double_blind)
 
-    def enable_double_blind(self, read_reviewers = False, read_area_chairs = False, read_program_chairs = False):
-        self.conference.set_double_blind(True)
         additional_readers = []
-        if read_reviewers:
+        if reviewers_read_original:
             additional_readers.append(self.conference.get_reviewers_id())
-        if read_area_chairs:
+        if area_chairs_read_original:
             additional_readers.append(self.conference.get_area_chairs_id())
-        if read_program_chairs:
-            additional_readers.append(self.conference.get_program_chairs_id())
         self.conference.set_original_readers(additional_readers)
 
     def set_submission_public(self, submission_public):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -195,6 +195,7 @@ class Conference(object):
 
     def get_submission_readers(self):
         return [
+            self.get_program_chairs_id(),
             self.get_area_chairs_id(),
             self.get_reviewers_id()
         ]
@@ -605,7 +606,7 @@ class ConferenceBuilder(object):
     def set_double_blind(self, double_blind = True, reviewers_read_original = False, area_chairs_read_original = False):
         self.conference.set_double_blind(double_blind)
 
-        additional_readers = []
+        additional_readers = [self.conference.get_program_chairs_id()]
         if reviewers_read_original:
             additional_readers.append(self.conference.get_reviewers_id())
         if area_chairs_read_original:

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -10,15 +10,15 @@ from .. import tools
 
 class SubmissionInvitation(openreview.Invitation):
 
-    def __init__(self, conference_id, conference_short_name, due_date, name, public = False, subject_areas = None, additional_fields = None, remove_fields = []):
+    def __init__(self, conference, due_date, readers, additional_fields, remove_fields):
 
         content = invitations.submission.copy()
 
-        if subject_areas:
+        if conference.get_subject_areas():
             content['subject_areas'] = {
                 'order' : 5,
                 'description' : "Select or type subject area",
-                'values-dropdown': subject_areas,
+                'values-dropdown': conference.get_subject_areas(),
                 'required': True
             }
 
@@ -30,27 +30,14 @@ class SubmissionInvitation(openreview.Invitation):
             value['order'] = order
             content[key] = value
 
-        readers = {
-            'values-copied': [
-                conference_id,
-                '{content.authorids}',
-                '{signatures}'
-            ]
-        }
-
-        if public:
-            readers = {
-                'values': ['everyone']
-            }
-
         with open(os.path.join(os.path.dirname(__file__), 'templates/submissionProcess.js')) as f:
             file_content = f.read()
-            file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference_short_name + "';")
-            super(SubmissionInvitation, self).__init__(id = conference_id + '/-/' + name,
+            file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_short_name() + "';")
+            super(SubmissionInvitation, self).__init__(id = conference.get_submission_id(),
                 duedate = tools.datetime_millis(due_date),
                 readers = ['everyone'],
-                writers = [conference_id],
-                signatures = [conference_id],
+                writers = [conference.get_id()],
+                signatures = [conference.get_id()],
                 invitees = ['~'],
                 reply = {
                     'forum': None,
@@ -58,7 +45,7 @@ class SubmissionInvitation(openreview.Invitation):
                     'readers': readers,
                     'writers': {
                         'values-copied': [
-                            conference_id,
+                            conference.get_id(),
                             '{content.authorids}',
                             '{signatures}'
                         ]
@@ -420,24 +407,38 @@ class InvitationBuilder(object):
 
         return merged_options
 
-    def set_submission_invitation(self, conference_id, due_date, options = {}):
+    def set_submission_invitation(self, conference, due_date, additional_fields, remove_fields):
 
-        default_options = {
-            'public': False,
-            'subject_areas': None,
-            'additional_fields': None
-        }
+        readers = {}
 
-        built_options = self.__build_options(default_options, options)
+        ## TODO: move this to an object
+        if conference.double_blind:
+            readers = {
+                'values-copied': [
+                    conference.get_id(),
+                    '{content.authorids}',
+                    '{signatures}'
+                ] + conference.get_original_readers()
+            }
+        else:
+            if conference.submission_public:
+                readers = {
+                    'values': ['everyone']
+                }
+            else:
+                readers = {
+                    'values-copied': [
+                        conference.get_id(),
+                        '{content.authorids}',
+                        '{signatures}'
+                    ] + conference.get_submission_readers()
+                }
 
-        invitation = SubmissionInvitation(conference_id = conference_id,
-            conference_short_name = built_options.get('conference_short_name'),
+        invitation = SubmissionInvitation(conference = conference,
             due_date = due_date,
-            name = built_options.get('submission_name'),
-            public = built_options.get('public'),
-            subject_areas = built_options.get('subject_areas'),
-            additional_fields = built_options.get('additional_fields'),
-            remove_fields = built_options.get('remove_fields'))
+            readers = readers,
+            additional_fields = additional_fields,
+            remove_fields = remove_fields)
 
         return self.client.post_invitation(invitation)
 

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -30,9 +30,10 @@ class TestCommentNotification():
         'instructions': 'Full papers contain well-validated applications or methodological developments of deep learning algorithms in medical imaging. There is no strict limit on paper length. However, we strongly recommend keeping full papers at 8 pages (excluding references and acknowledgements). An appendix section can be added if needed with additional details but must be compiled into a single pdf. The appropriateness of using pages over the recommended page length will be judged by reviewers. All accepted papers will be presented as posters with a selection of these papers will also be invited for oral presentation.<br/><br/> <p><strong>Questions or Concerns</strong></p><p>Please contact the OpenReview support team at <a href=\"mailto:info@openreview.net\">info@openreview.net</a> with any questions or concerns about the OpenReview platform.<br/>    Please contact the MIDL 2019 Program Chairs at <a href=\"mailto:program-chairs@midl.io\">program-chairs@midl.io</a> with any questions or concerns about conference administration or policy.</p><p>We are aware that some email providers inadequately filter emails coming from openreview.net as spam so please check your spam folder regularly.</p>'
         })
         builder.set_conference_submission_name('Full_Submission')
+        builder.set_submission_public(True)
         conference = builder.get_result()
 
-        invitation = conference.open_submissions(due_date = datetime.datetime(2018, 12, 14, 8, 00), public = True)
+        invitation = conference.open_submissions(due_date = datetime.datetime(2018, 12, 14, 8, 00))
 
         note = openreview.Note(invitation = invitation.id,
             readers = ['everyone'],

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -229,6 +229,7 @@ class TestDoubleBlindConference():
         })
         builder.set_double_blind(True)
         conference = builder.get_result()
+
         invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00))
         assert invitation
         assert invitation.duedate == 1570298400000
@@ -606,6 +607,7 @@ class TestDoubleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
+        builder.set_submission_public(True)
         conference = builder.get_result()
 
         with pytest.raises(openreview.OpenReviewException, match=r'Conference is not double blind'):
@@ -614,7 +616,7 @@ class TestDoubleBlindConference():
         builder.set_double_blind(True)
         conference = builder.get_result()
 
-        blind_submissions = conference.create_blind_submissions(public = True)
+        blind_submissions = conference.create_blind_submissions()
         assert blind_submissions
         assert len(blind_submissions) == 1
 

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -87,10 +87,11 @@ class TestSingleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('NIPS.cc/2018/Workshop/MLITS')
+        builder.set_submission_public(True)
         conference = builder.get_result()
         assert conference, 'conference is None'
 
-        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00), public = True)
+        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00))
         assert invitation
         assert invitation.duedate == 1570298400000
 
@@ -120,8 +121,9 @@ class TestSingleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('NIPS.cc/2018/Workshop/MLITS')
+        builder.set_submission_public(True)
         conference = builder.get_result()
-        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00), public = True)
+        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00))
 
         assert invitation
         assert invitation.id == 'NIPS.cc/2018/Workshop/MLITS/-/Submission'


### PR DESCRIPTION
- Use the builder to set if the submission paper is public or not, instead of using open_submissions method. Because we use the public settings in two different places: single blind submissions invitation and double blind submission invitation. 
- When setting the conference double blind: you can specify who can read the original notes. By default is only authors and pcs, but you could add reviewers or area chairs (for example: COLT.)