### PR TITLE
Feature/invitation start date

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ OpenReview Python library
 
 
 [![CircleCI](https://circleci.com/gh/iesl/openreview-py.svg?style=svg)](https://circleci.com/gh/iesl/openreview-py)
+[![Documentation Status](https://readthedocs.org/projects/openreview-py/badge/?version=latest)](https://openreview-py.readthedocs.io/en/latest/?badge=latest)
 
 Classes:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -31,3 +31,17 @@ Tools
 
 .. automodule:: tools
    :members:
+
+
+Conference Builder
+-------------------
+
+.. automodule:: conference.builder
+
+.. autoclass:: Conference
+   :members:
+
+.. autoclass:: ConferenceBuilder
+   :members:
+
+

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -372,10 +372,10 @@ class Conference(object):
         notes_iterator = self.get_submissions()
         return self.invitation_builder.set_meta_review_invitation(self, notes_iterator, name, start_date, due_date, public)
 
-    def open_revise_submissions(self, name = 'Revision', start_date = None, due_date = None, public = False, additional_fields = {}, remove_fields = []):
+    def open_revise_submissions(self, name = 'Revision', start_date = None, due_date = None, additional_fields = {}, remove_fields = []):
         invitation = self.client.get_invitation(self.get_submission_id())
         notes_iterator = self.get_submissions(blind=False)
-        return self.invitation_builder.set_revise_submission_invitation(self, notes_iterator, name, start_date, due_date, public, invitation.reply['content'], additional_fields, remove_fields)
+        return self.invitation_builder.set_revise_submission_invitation(self, notes_iterator, name, start_date, due_date, invitation.reply['content'], additional_fields, remove_fields)
 
     def close_revise_submissions(self, name):
         return self.__expire_invitations(name)

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -7,10 +7,11 @@ import openreview
 from .. import invitations
 from .. import tools
 
+SUBMISSION_BUFFER_DATE = 30
 
 class SubmissionInvitation(openreview.Invitation):
 
-    def __init__(self, conference, due_date, readers, additional_fields, remove_fields):
+    def __init__(self, conference, start_date, due_date, readers, additional_fields, remove_fields):
 
         content = invitations.submission.copy()
 
@@ -34,7 +35,9 @@ class SubmissionInvitation(openreview.Invitation):
             file_content = f.read()
             file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_short_name() + "';")
             super(SubmissionInvitation, self).__init__(id = conference.get_submission_id(),
+                cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
+                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SUBMISSION_BUFFER_DATE)),
                 readers = ['everyone'],
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],
@@ -91,7 +94,7 @@ class BlindSubmissionsInvitation(openreview.Invitation):
 
 class SubmissionRevisionInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, note, due_date, public, submission_content, additional_fields, remove_fields):
+    def __init__(self, conference, name, note, start_date, due_date, public, submission_content, additional_fields, remove_fields):
 
         content = submission_content.copy()
 
@@ -120,6 +123,7 @@ class SubmissionRevisionInvitation(openreview.Invitation):
             file_content = f.read()
             file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_short_name() + "';")
             super(SubmissionRevisionInvitation, self).__init__(id = conference.get_id() + '/-/Paper' + str(note.number) + '/' + name,
+                cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
                 readers = ['everyone'],
                 writers = [conference.get_id()],
@@ -145,7 +149,7 @@ class SubmissionRevisionInvitation(openreview.Invitation):
             )
 
 class BidInvitation(openreview.Invitation):
-    def __init__(self, conference, due_date, request_count, with_area_chairs):
+    def __init__(self, conference, start_date, due_date, request_count, with_area_chairs):
 
         readers = [
             conference.get_id(),
@@ -159,6 +163,7 @@ class BidInvitation(openreview.Invitation):
             invitees.append(conference.get_area_chairs_id())
 
         super(BidInvitation, self).__init__(id = conference.get_bid_id(),
+            cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             readers = readers,
             writers = [conference.get_id()],
@@ -189,11 +194,10 @@ class BidInvitation(openreview.Invitation):
 
 class PublicCommentInvitation(openreview.Invitation):
 
-    def __init__(self, conference_id, name, number, paper_id, anonymous = False):
+    def __init__(self, conference, name, note, start_date, anonymous = False):
 
         content = invitations.comment.copy()
 
-        prefix = conference_id + '/Paper' + str(number) + '/'
         signatures_regex = '~.*'
 
         if anonymous:
@@ -201,35 +205,36 @@ class PublicCommentInvitation(openreview.Invitation):
 
         with open(os.path.join(os.path.dirname(__file__), 'templates/commentProcess.js')) as f:
             file_content = f.read()
-            file_content = file_content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference_id + "';")
-            file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference_id + "';")
-            super(PublicCommentInvitation, self).__init__(id = conference_id + '/-/Paper' + str(number) + '/' + name,
+            file_content = file_content.replace("var CONFERENCE_ID = '';", "var CONFERENCE_ID = '" + conference.get_id() + "';")
+            file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_id() + "';")
+            super(PublicCommentInvitation, self).__init__(id = conference.get_id() + '/-/Paper' + str(note.number) + '/' + name,
+                cdate = tools.datetime_millis(start_date),
                 readers = ['everyone'],
-                writers = [conference_id],
-                signatures = [conference_id],
+                writers = [conference.get_id()],
+                signatures = [conference.get_id()],
                 invitees = ['~'],
                 noninvitees = [
-                    prefix + "Authors",
-                    prefix + "Reviewers",
-                    prefix + "Area_Chairs",
-                    conference_id + '/' + "Program_Chairs"
+                    conference.get_authors_id(number = note.number),
+                    conference.get_reviewers_id(number = note.number),
+                    conference.get_area_chairs_id(number = note.number),
+                    conference.get_id() + '/' + "Program_Chairs"
                 ],
                 reply = {
-                    'forum': paper_id,
+                    'forum': note.id,
                     'replyto': None,
                     'readers': {
                         "description": "Select all user groups that should be able to read this comment.",
                         "values-dropdown": [
                             "everyone",
-                            prefix + "Authors",
-                            prefix + "Reviewers",
-                            prefix + "Area_Chairs",
-                            conference_id + '/' + "Program_Chairs"
+                            conference.get_authors_id(number = note.number),
+                            conference.get_reviewers_id(number = note.number),
+                            conference.get_area_chairs_id(number = note.number),
+                            conference.get_id() + '/' + "Program_Chairs"
                         ]
                     },
                     'writers': {
                         'values-copied': [
-                            conference_id,
+                            conference.get_id(),
                             '{signatures}'
                         ]
                     },
@@ -244,11 +249,11 @@ class PublicCommentInvitation(openreview.Invitation):
 
 class OfficialCommentInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, number, paper_id, anonymous = False):
+    def __init__(self, conference, name, note, start_date, anonymous = False):
 
         content = invitations.comment.copy()
 
-        prefix = conference.id + '/Paper' + str(number) + '/'
+        prefix = conference.get_id() + '/Paper' + str(note.number) + '/'
         signatures_regex = '~.*'
 
         if anonymous:
@@ -264,26 +269,27 @@ class OfficialCommentInvitation(openreview.Invitation):
             file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.reviewers_name + "';")
             file_content = file_content.replace("var AREA_CHAIRS_NAME = '';", "var AREA_CHAIRS_NAME = '" + conference.area_chairs_name + "';")
             file_content = file_content.replace("var PROGRAM_CHAIRS_NAME = '';", "var PROGRAM_CHAIRS_NAME = '" + conference.program_chairs_name + "';")
-            super(OfficialCommentInvitation, self).__init__(id = conference.id + '/-/Paper' + str(number) + '/' + name,
+            super(OfficialCommentInvitation, self).__init__(id = conference.id + '/-/Paper' + str(note.number) + '/' + name,
+                cdate = tools.datetime_millis(start_date),
                 readers = ['everyone'],
                 writers = [conference.id],
                 signatures = [conference.id],
                 invitees = [
-                    prefix + conference.authors_name,
-                    prefix + conference.reviewers_name,
-                    prefix + conference.area_chairs_name,
-                    conference.id + '/' + conference.program_chairs_name
+                    conference.get_authors_id(number = note.number),
+                    conference.get_reviewers_id(number = note.number),
+                    conference.get_area_chairs_id(number = note.number),
+                    conference.get_program_chairs_id()
                 ],
                 reply = {
-                    'forum': paper_id,
+                    'forum': note.id,
                     'replyto': None,
                     'readers': {
                         "description": "Select all user groups that should be able to read this comment.",
                         "values-dropdown": [
-                            prefix + conference.authors_name,
-                            prefix + conference.reviewers_name,
-                            prefix + conference.area_chairs_name,
-                            conference.id + '/' + conference.program_chairs_name
+                            conference.get_authors_id(number = note.number),
+                            conference.get_reviewers_id(number = note.number),
+                            conference.get_area_chairs_id(number = note.number),
+                            conference.get_program_chairs_id()
                         ]
                     },
                     'writers': {
@@ -303,18 +309,18 @@ class OfficialCommentInvitation(openreview.Invitation):
 
 class ReviewInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, number, paper_id, due_date, public):
+    def __init__(self, conference, name, note, start_date, due_date, public):
         content = invitations.review.copy()
 
-        prefix = conference.id + '/Paper' + str(number) + '/'
+        prefix = conference.get_id() + '/Paper' + str(note.number) + '/'
         readers = ['everyone']
 
         if not public:
             readers = [
-                prefix + conference.authors_name,
-                prefix + conference.reviewers_name,
-                prefix + conference.area_chairs_name,
-                conference.id + '/' + conference.program_chairs_name
+                conference.get_authors_id(number = note.number),
+                conference.get_reviewers_id(number = note.number),
+                conference.get_area_chairs_id(number = note.number),
+                conference.get_program_chairs_id()
             ]
 
         with open(os.path.join(os.path.dirname(__file__), 'templates/reviewProcess.js')) as f:
@@ -326,15 +332,16 @@ class ReviewInvitation(openreview.Invitation):
             file_content = file_content.replace("var REVIEWERS_NAME = '';", "var REVIEWERS_NAME = '" + conference.reviewers_name + "';")
             file_content = file_content.replace("var AREA_CHAIRS_NAME = '';", "var AREA_CHAIRS_NAME = '" + conference.area_chairs_name + "';")
             file_content = file_content.replace("var PROGRAM_CHAIRS_NAME = '';", "var PROGRAM_CHAIRS_NAME = '" + conference.program_chairs_name + "';")
-            super(ReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(number) + '/' + name,
+            super(ReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(note.number) + '/' + name,
+                cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
                 readers = ['everyone'],
                 writers = [conference.id],
                 signatures = [conference.id],
-                invitees = [prefix + conference.reviewers_name],
+                invitees = [conference.get_reviewers_id(number = note.number)],
                 reply = {
-                    'forum': paper_id,
-                    'replyto': paper_id,
+                    'forum': note.id,
+                    'replyto': note.id,
                     'readers': {
                         "description": "Select all user groups that should be able to read this comment.",
                         "values": readers
@@ -354,36 +361,37 @@ class ReviewInvitation(openreview.Invitation):
 
 class MetaReviewInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, number, paper_id, due_date, public):
+    def __init__(self, conference, name, note, start_date, due_date, public):
         content = invitations.meta_review.copy()
 
         readers = ['everyone']
 
         if not public:
             readers = [
-                conference.get_area_chairs_id(number),
+                conference.get_area_chairs_id(note.number),
                 conference.get_program_chairs_id()
             ]
 
-        super(MetaReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(number) + '/' + name,
+        super(MetaReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(note.number) + '/' + name,
+            cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             readers = ['everyone'],
             writers = [conference.id],
             signatures = [conference.id],
-            invitees = [conference.get_area_chairs_id(number)],
+            invitees = [conference.get_area_chairs_id(note.number)],
             reply = {
-                'forum': paper_id,
-                'replyto': paper_id,
+                'forum': note.id,
+                'replyto': note.id,
                 'readers': {
                     "description": "Select all user groups that should be able to read this comment.",
                     "values": readers
                 },
                 'writers': {
-                    'values-regex': conference.get_area_chairs_id(number)[:-1] + '[0-9]+',
+                    'values-regex': conference.get_area_chairs_id(note.number)[:-1] + '[0-9]+',
                     'description': 'How your identity will be displayed.'
                 },
                 'signatures': {
-                    'values-regex': conference.get_area_chairs_id(number)[:-1] + '[0-9]+',
+                    'values-regex': conference.get_area_chairs_id(note.number)[:-1] + '[0-9]+',
                     'description': 'How your identity will be displayed.'
                 },
                 'content': content
@@ -407,7 +415,7 @@ class InvitationBuilder(object):
 
         return merged_options
 
-    def set_submission_invitation(self, conference, due_date, additional_fields, remove_fields):
+    def set_submission_invitation(self, conference, start_date, due_date, additional_fields, remove_fields):
 
         readers = {}
 
@@ -435,6 +443,7 @@ class InvitationBuilder(object):
                 }
 
         invitation = SubmissionInvitation(conference = conference,
+            start_date = start_date,
             due_date = due_date,
             readers = readers,
             additional_fields = additional_fields,
@@ -448,36 +457,36 @@ class InvitationBuilder(object):
 
         return  self.client.post_invitation(invitation)
 
-    def set_bid_invitation(self, conference, due_date, request_count, with_area_chairs):
+    def set_bid_invitation(self, conference, start_date, due_date, request_count, with_area_chairs):
 
-        invitation = BidInvitation(conference, due_date, request_count, with_area_chairs)
+        invitation = BidInvitation(conference, start_date, due_date, request_count, with_area_chairs)
 
         return self.client.post_invitation(invitation)
 
-    def set_public_comment_invitation(self, conference_id, notes, name, anonymous):
+    def set_public_comment_invitation(self, conference, notes, name, start_date, anonymous):
 
         for note in notes:
-            self.client.post_invitation(PublicCommentInvitation(conference_id, name, note.number, note.id, anonymous))
+            self.client.post_invitation(PublicCommentInvitation(conference, name, note, start_date, anonymous))
 
-    def set_private_comment_invitation(self, conference, notes, name, anonymous):
-
-        for note in notes:
-            self.client.post_invitation(OfficialCommentInvitation(conference, name, note.number, note.id, anonymous))
-
-    def set_review_invitation(self, conference, notes, name, due_date, public):
+    def set_private_comment_invitation(self, conference, notes, name, start_date, anonymous):
 
         for note in notes:
-            self.client.post_invitation(ReviewInvitation(conference, name, note.number, note.id, due_date, public))
+            self.client.post_invitation(OfficialCommentInvitation(conference, name, note, start_date, anonymous))
 
-    def set_meta_review_invitation(self, conference, notes, name, due_date, public):
-
-        for note in notes:
-            self.client.post_invitation(MetaReviewInvitation(conference, name, note.number, note.id, due_date, public))
-
-    def set_revise_submission_invitation(self, conference, notes, name, due_date, public, submission_content, additional_fields, remove_fields):
+    def set_review_invitation(self, conference, notes, name, start_date, due_date, public):
 
         for note in notes:
-            self.client.post_invitation(SubmissionRevisionInvitation(conference, name, note, due_date, public, submission_content, additional_fields, remove_fields))
+            self.client.post_invitation(ReviewInvitation(conference, name, note, start_date, due_date, public))
+
+    def set_meta_review_invitation(self, conference, notes, name, start_date, due_date, public):
+
+        for note in notes:
+            self.client.post_invitation(MetaReviewInvitation(conference, name, note, start_date, due_date, public))
+
+    def set_revise_submission_invitation(self, conference, notes, name, start_date, due_date, public, submission_content, additional_fields, remove_fields):
+
+        for note in notes:
+            self.client.post_invitation(SubmissionRevisionInvitation(conference, name, note, start_date, due_date, public, submission_content, additional_fields, remove_fields))
 
     def set_reviewer_recruiter_invitation(self, conference_id, options = {}):
 
@@ -518,7 +527,7 @@ class InvitationBuilder(object):
 
             return self.client.post_invitation(invitation)
 
-    def set_recommendation_invitation(self, conference, due_date, notes_iterator, assingment_notes_iterator):
+    def set_recommendation_invitation(self, conference, start_date, due_date, notes_iterator, assingment_notes_iterator):
 
         assignment_note_by_forum = {}
         for assignment_note in assingment_notes_iterator:
@@ -527,6 +536,7 @@ class InvitationBuilder(object):
         # Create super invitation with a webfield
         recommendation_invitation = openreview.Invitation(
             id = conference.get_id() + '/-/Recommendation',
+            cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             readers = [conference.get_program_chairs_id(), conference.get_area_chairs_id()],
             invitees = [],

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -7,7 +7,8 @@ import openreview
 from .. import invitations
 from .. import tools
 
-SUBMISSION_BUFFER_DATE = 30
+SHORT_BUFFER_MIN = 30
+LONG_BUFFER_DAYS = 10
 
 class SubmissionInvitation(openreview.Invitation):
 
@@ -37,7 +38,7 @@ class SubmissionInvitation(openreview.Invitation):
             super(SubmissionInvitation, self).__init__(id = conference.get_submission_id(),
                 cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
-                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SUBMISSION_BUFFER_DATE)),
+                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
                 readers = ['everyone'],
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],
@@ -63,11 +64,11 @@ class SubmissionInvitation(openreview.Invitation):
 
 class BlindSubmissionsInvitation(openreview.Invitation):
 
-    def __init__(self, conference_id, invitation_id):
-        super(BlindSubmissionsInvitation, self).__init__(id = invitation_id,
+    def __init__(self, conference):
+        super(BlindSubmissionsInvitation, self).__init__(id = conference.get_blind_submission_id(),
             readers = ['everyone'],
-            writers = [conference_id],
-            signatures = [conference_id],
+            writers = [conference.get_id()],
+            signatures = [conference.get_id()],
             invitees = ['~'],
             reply = {
                 'forum': None,
@@ -76,10 +77,10 @@ class BlindSubmissionsInvitation(openreview.Invitation):
                     'values-regex': '.*'
                 },
                 'writers': {
-                    'values': [conference_id]
+                    'values': [conference.get_id()]
                 },
                 'signatures': {
-                    'values': [conference_id]
+                    'values': [conference.get_id()]
                 },
                 'content': {
                     'authors': {
@@ -165,6 +166,7 @@ class BidInvitation(openreview.Invitation):
         super(BidInvitation, self).__init__(id = conference.get_bid_id(),
             cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
+            expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
             readers = readers,
             writers = [conference.get_id()],
             signatures = [conference.get_id()],
@@ -335,6 +337,7 @@ class ReviewInvitation(openreview.Invitation):
             super(ReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(note.number) + '/' + name,
                 cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
+                expdate = tools.datetime_millis(due_date + datetime.timedelta(days = LONG_BUFFER_DAYS)),
                 readers = ['everyone'],
                 writers = [conference.id],
                 signatures = [conference.id],
@@ -375,6 +378,7 @@ class MetaReviewInvitation(openreview.Invitation):
         super(MetaReviewInvitation, self).__init__(id = conference.id + '/-/Paper' + str(note.number) + '/' + name,
             cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
+            expdate = tools.datetime_millis(due_date + datetime.timedelta(days = LONG_BUFFER_DAYS)),
             readers = ['everyone'],
             writers = [conference.id],
             signatures = [conference.id],
@@ -453,7 +457,7 @@ class InvitationBuilder(object):
 
     def set_blind_submission_invitation(self, conference):
 
-        invitation = BlindSubmissionsInvitation(conference_id = conference.get_id(), invitation_id = conference.get_blind_submission_id())
+        invitation = BlindSubmissionsInvitation(conference = conference)
 
         return  self.client.post_invitation(invitation)
 

--- a/openreview/conference/templates/tabsConferenceWebfield.js
+++ b/openreview/conference/templates/tabsConferenceWebfield.js
@@ -19,7 +19,7 @@ var AUTHORS_ID = '';
 var HEADER = {};
 
 var WILDCARD_INVITATION = CONFERENCE_ID + '/-/.*';
-var BUFFER = 1000 * 60;  // 1 minutes
+var BUFFER = 0;  // deprecated
 var PAGE_SIZE = 50;
 
 var paperDisplayOptions = {

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -915,11 +915,14 @@ def timestamp_GMT(year, month, day, hour=0, minute=0, second=0):
 
 def datetime_millis(dt):
     '''
-    Convets a datetim to milliseconds.
+    Convets a datetime to milliseconds.
 
     '''
-    epoch = datetime.datetime.utcfromtimestamp(0)
-    return int((dt - epoch).total_seconds() * 1000)
+    if isinstance(dt, datetime.datetime):
+        epoch = datetime.datetime.utcfromtimestamp(0)
+        return int((dt - epoch).total_seconds() * 1000)
+
+    return dt
 
 def recruit_reviewer(client, user, first,
     hash_seed,

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -3,6 +3,7 @@ import openreview
 import pytest
 import requests
 import datetime
+import time
 import os
 import re
 from selenium.webdriver.common.by import By
@@ -33,7 +34,8 @@ class TestCommentNotification():
         builder.set_submission_public(True)
         conference = builder.get_result()
 
-        invitation = conference.open_submissions(due_date = datetime.datetime(2018, 12, 14, 8, 00))
+        now = datetime.datetime.now() + datetime.timedelta(hours = (time.timezone / 3600.0))
+        invitation = conference.open_submissions(due_date = now + datetime.timedelta(minutes = 10))
 
         note = openreview.Note(invitation = invitation.id,
             readers = ['everyone'],

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -53,7 +53,7 @@ class TestCommentNotification():
         note = test_client.post_note(note)
         assert note
 
-        conference.close_submissions(freeze_submissions = True)
+        conference.close_submissions()
 
         conference.set_authors()
         conference.set_program_chairs(emails= ['programchair@midl.io'])

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -601,7 +601,7 @@ class TestDoubleBlindConference():
         conference.close_submissions()
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Submission')
         submission = notes[0]
-        assert ['AKBC.ws/2019/Conference'] == submission.writers
+        assert ['~Test_User1', 'peter@mail.com', 'andrew@mail.com'] == submission.writers
 
         request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, test_client.token)
 

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -3,6 +3,7 @@ import openreview
 import pytest
 import requests
 import datetime
+import time
 import os
 
 class TestSingleBlindConference():
@@ -91,13 +92,32 @@ class TestSingleBlindConference():
         conference = builder.get_result()
         assert conference, 'conference is None'
 
-        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00))
+        now = datetime.datetime.now() + datetime.timedelta(hours = (time.timezone / 3600.0))
+
+        invitation = conference.open_submissions(start_date = now + datetime.timedelta(minutes = 10), due_date = now + datetime.timedelta(minutes = 40))
         assert invitation
-        assert invitation.duedate == 1570298400000
+        assert invitation.cdate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 10))
+        assert invitation.duedate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 40))
+        assert invitation.expdate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 70))
 
         posted_invitation = client.get_invitation(id = 'NIPS.cc/2018/Workshop/MLITS/-/Submission')
         assert posted_invitation
-        assert posted_invitation.duedate == 1570298400000
+        assert posted_invitation.cdate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 10))
+        assert posted_invitation.duedate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 40))
+        assert posted_invitation.expdate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 70))
+
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS")
+
+        assert "NIPS 2018 Workshop MLITS | OpenReview" in selenium.title
+        invitation_panel = selenium.find_element_by_id('invitation')
+        assert invitation_panel
+        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
+
+        invitation = conference.open_submissions(start_date = now - datetime.timedelta(minutes = 10), due_date = now + datetime.timedelta(minutes = 40))
+        assert invitation
+        assert invitation.cdate == openreview.tools.datetime_millis(now - datetime.timedelta(minutes = 10))
+        assert invitation.duedate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 40))
+        assert invitation.expdate == openreview.tools.datetime_millis(now + datetime.timedelta(minutes = 70))
 
         request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS")
 
@@ -123,7 +143,11 @@ class TestSingleBlindConference():
         builder.set_conference_id('NIPS.cc/2018/Workshop/MLITS')
         builder.set_submission_public(True)
         conference = builder.get_result()
-        invitation = conference.open_submissions(due_date = datetime.datetime(2019, 10, 5, 18, 00))
+
+        now = datetime.datetime.now() + datetime.timedelta(hours = (time.timezone / 3600.0))
+
+        invitation = conference.open_submissions(due_date = now + datetime.timedelta(minutes = 40))
+
 
         assert invitation
         assert invitation.id == 'NIPS.cc/2018/Workshop/MLITS/-/Submission'

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -278,7 +278,7 @@ class TestSingleBlindConference():
         conference.close_submissions()
         notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Submission')
         submission = notes[0]
-        assert ['NIPS.cc/2018/Workshop/MLITS'] == submission.writers
+        assert ['~Test_User1', 'peter@mail.com', 'andrew@mail.com'] == submission.writers
 
         request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, test_client.token)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,7 +10,7 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 5, "Invitations could not be retrieved"
+        assert len(invitations) == 2, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)


### PR DESCRIPTION
- Set a start date(cdate) to all the current invitations implemented. 
- Now close_invitations are not longer needed unless you want to force the expiration date to 'now'. 
- Predefine buffers for the hard due date (expdate). 30 minutes for submissions invitations and 10 days for reviews and meta reviews. 