### PR TITLE
set a default profile to compute conflict of interest using at least the email address

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -73,6 +73,27 @@ class Matching(object):
 
         return entries
 
+    def _get_profiles(self, client, ids_or_emails):
+        ids = []
+        emails = []
+        for member in ids_or_emails:
+            if '~' in member:
+                ids.append(member)
+            else:
+                emails.append(member)
+
+        profiles = client.search_profiles(ids = ids)
+
+        profile_by_email = client.search_profiles(emails = emails)
+        for email in emails:
+            profiles.append(profile_by_email.get(email, openreview.Profile(id = email,
+            content = {
+                'emails': [email],
+                'preferredEmail': email
+            })))
+
+        return profiles
+
     def post_metadata_note(self,
         client,
         note,
@@ -85,7 +106,7 @@ class Matching(object):
         if note.details.get('original'):
             authorids = note.details['original']['content']['authorids']
         paper_bid_jsons = note.details['tags']
-        paper_author_profiles = client.get_profiles(authorids)
+        paper_author_profiles = self._get_profiles(client, authorids)
         print('Paper',note.id)
         entries = self._build_entries(paper_author_profiles, reviewer_profiles, paper_bid_jsons, paper_tpms_scores, manual_conflicts_by_id)
 
@@ -140,7 +161,7 @@ class Matching(object):
         client = conference.client
         CONFERENCE_ID = conference.get_id()
         PROGRAM_CHAIRS_ID = conference.get_program_chairs_id()
-        SUBMISSION_ID = conference.get_submission_id()
+        SUBMISSION_ID = conference.get_blind_submission_id()
         METADATA_INV_ID = CONFERENCE_ID + '/-/Paper_Metadata'
         REVIEWERS_ID = conference.get_reviewers_id()
         AREA_CHAIRS_ID = conference.get_area_chairs_id()
@@ -251,7 +272,7 @@ class Matching(object):
                         'order': 7
                     },
                     'paper_invitation': {
-                        'value': CONFERENCE_ID + '/-/Blind_Submission',
+                        'value': SUBMISSION_ID,
                         'required': True,
                         'description': 'Invitation to get the configuration note',
                         'order': 8
@@ -317,20 +338,14 @@ class Matching(object):
         reviewers_group = openreview.tools.replace_members_with_ids(client,reviewers_group)
         if not all(['~' in member for member in reviewers_group.members]):
             print('WARNING: not all reviewers have been converted to profile IDs. Members without profiles will not have metadata created.')
-        valid_reviewers_ids = [r for r in reviewers_group.members if '~' in r]
-
-        reviewers_profiles = client.get_profiles(valid_reviewers_ids)
 
         areachairs_group = client.get_group(AREA_CHAIRS_ID)
         # The areachairs are all emails so convert to tilde ids
         areachairs_group = openreview.tools.replace_members_with_ids(client,areachairs_group)
         if not all(['~' in member for member in areachairs_group.members]):
             print('WARNING: not all area chairs have been converted to profile IDs. Members without profiles will not have metadata created.')
-        valid_ac_ids = [r for r in areachairs_group.members if '~' in r]
 
-        ac_profiles = client.get_profiles(valid_ac_ids)
-
-        user_profiles = ac_profiles + reviewers_profiles
+        user_profiles = self._get_profiles(client, reviewers_group.members + areachairs_group.members)
 
 
         # create metadata

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -259,7 +259,7 @@ class Client(object):
         response = self.__handle_response(response)
         return [Profile.from_json(p) for p in response.json()['profiles']]
 
-    def search_profiles(self, emails, ids, term):
+    def search_profiles(self, emails = None, ids = None, term = None):
 
         if term:
             response = requests.get(self.profiles_search_url, params = { 'term': term }, headers = self.headers)
@@ -269,7 +269,7 @@ class Client(object):
         if emails:
             response = requests.post(self.profiles_search_url, json = {'emails': emails}, headers = self.headers)
             response = self.__handle_response(response)
-            return { p['email'] : Profile.from_json(p['profile'])
+            return { p['email'] : Profile.from_json(p)
                 for p in response.json()['profiles'] }
 
         if ids:

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1116,8 +1116,8 @@ def get_conflicts(author_profiles, user_profile):
     author_emails = set()
     author_relations = set()
 
-    for author_email, profile in author_profiles.items():
-        author_info = get_author_info(profile, author_email)
+    for profile in author_profiles:
+        author_info = get_profile_info(profile)
 
         author_domains.update(author_info['domains'])
         author_emails.update(author_info['emails'])
@@ -1132,18 +1132,6 @@ def get_conflicts(author_profiles, user_profile):
     conflicts.update(author_emails.intersection(user_info['emails']))
 
     return list(conflicts)
-
-
-def get_author_info(profile, email):
-    if profile:
-        return get_profile_info(profile)
-    else:
-        return {
-            'domains': openreview.tools.subdomains(email),
-            'emails': [email],
-            'relations': []
-        }
-
 
 def get_profile_info(profile):
     domains = set()


### PR DESCRIPTION
Fixes https://github.com/iesl/openreview-py/issues/234

Michael, please review carefully, I may miss something. I'm creating a default profile for the missing one to use for the conflict of interest computation. 

