### PR TITLE
Fix/double blind optional

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -314,7 +314,7 @@ class Conference(object):
                 '_bibtex': None
             }
 
-            if 'author_identity_visibility' in note.content:
+            if note.content.get('author_identity_visibility'):
                 content = {
                     "_bibtex": None
                 }

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -307,6 +307,18 @@ class Conference(object):
         blinded_notes = []
 
         for note in tools.iterget_notes(self.client, invitation = self.get_submission_id(), sort = 'number:asc'):
+
+            content = {
+                'authors': ['Anonymous'],
+                'authorids': [self.id],
+                '_bibtex': None
+            }
+
+            if 'author_identity_visibility' in note.content:
+                content = {
+                    "_bibtex": None
+                }
+
             blind_note = openreview.Note(
                 original= note.id,
                 invitation= self.get_blind_submission_id(),
@@ -314,11 +326,7 @@ class Conference(object):
                 signatures= [self.id],
                 writers= [self.id],
                 readers= [self.id],
-                content= {
-                    "authors": ['Anonymous'],
-                    "authorids": [self.id],
-                    "_bibtex": None
-                })
+                content= content)
 
             posted_blind_note = self.client.post_note(blind_note)
 
@@ -329,12 +337,10 @@ class Conference(object):
                     self.get_authors_id(number = posted_blind_note.number)
                 ]
 
-            posted_blind_note.content = {
-                'authorids': [self.get_authors_id(number = posted_blind_note.number)],
-                'authors': ['Anonymous'],
-                '_bibtex': None #Create bibtext automatically
-            }
+            if 'authorids' in content:
+                content['authorids'] = [self.get_authors_id(number = posted_blind_note.number)]
 
+            posted_blind_note.content = content
             posted_blind_note = self.client.post_note(posted_blind_note)
             blinded_notes.append(posted_blind_note)
 

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -348,7 +348,7 @@ class Client(object):
         groups = [Group.from_json(g) for g in response.json()['groups']]
         return groups
 
-    def get_invitations(self, id = None, invitee = None, replytoNote = None, replyForum = None, signature = None, note = None, regex = None, tags = None, limit = None, offset = None, minduedate = None, duedate = None, pastdue = None, replyto = None, details = None):
+    def get_invitations(self, id = None, invitee = None, replytoNote = None, replyForum = None, signature = None, note = None, regex = None, tags = None, limit = None, offset = None, minduedate = None, duedate = None, pastdue = None, replyto = None, details = None, expired = None):
         """
         Returns a list of Invitation objects based on the filters provided.
         """
@@ -377,6 +377,7 @@ class Client(object):
         params['details'] = details
         params['limit'] = limit
         params['offset'] = offset
+        params['expired'] = expired
 
         response = requests.get(self.invitations_url, params=params, headers=self.headers)
         response = self.__handle_response(response)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -x --driver=Firefox --driver-path=tests/drivers/geckodriver

--- a/tests/test_optional_double_blind.py
+++ b/tests/test_optional_double_blind.py
@@ -1,0 +1,118 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import openreview
+import pytest
+import requests
+import datetime
+import time
+import os
+import re
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import NoSuchElementException
+
+class TestOptionalDoubleBlind():
+
+    def test_anonymize_based_user_option(self, client, test_client, selenium, request_page):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+
+        builder.set_conference_id('icaps-conference.org/ICAPS/2019/Workshop/VRDIP')
+        builder.set_conference_name('Planning the Future: Economics and Value-Rational')
+        builder.set_conference_short_name('ICAPS Workshop 2019 VRDIP')
+        builder.set_homepage_header({
+        'title': 'Planning the Future: Economics and Value-Rational',
+        'subtitle': 'ICAPS 2019 Workshop',
+        'deadline': 'Submission Deadline: April 15, 2019',
+        'date': 'July 11, 2019',
+        'website': 'https://icaps19.icaps-conference.org/workshops/Planning-the-Future/index.html',
+        'location': 'Berkeley, CA, USA'
+        })
+        builder.set_double_blind(True)
+        builder.set_submission_public(True)   
+        conference = builder.get_result()
+        assert conference    
+
+        now = datetime.datetime.now() + datetime.timedelta(hours = (time.timezone / 3600.0))
+        invitation = conference.open_submissions(due_date = now + datetime.timedelta(minutes = 10), additional_fields = {
+            "anonymized": {
+                "order": 4,
+                "value-checkbox": "Anonymize author identities",
+                "required": False
+            }
+        })
+        assert invitation
+
+        note = openreview.Note(invitation = invitation.id,
+            readers = ['~Test_User1', 'peter@mail.com', 'andrew@mail.com'],
+            writers = ['~Test_User1', 'peter@mail.com', 'andrew@mail.com'],
+            signatures = ['~Test_User1'],
+            content = {
+                'title': 'Paper title',
+                'abstract': 'This is an abstract',
+                'authorids': ['test@mail.com', 'peter@mail.com', 'andrew@mail.com'],
+                'authors': ['Test User', 'Peter User', 'Andrew Mc'],
+                'anonymized': 'Anonymize author identities'
+            }
+        )
+        url = test_client.put_pdf(os.path.join(os.path.dirname(__file__), 'data/paper.pdf'))
+        note.content['pdf'] = url
+        test_client.post_note(note)
+
+        # Author user
+        request_page(selenium, "http://localhost:3000/group?id=icaps-conference.org/ICAPS/2019/Workshop/VRDIP", test_client.token)
+        invitation_panel = selenium.find_element_by_id('invitation')
+        assert invitation_panel
+        assert len(invitation_panel.find_elements_by_tag_name('div')) == 1
+        assert 'ICAPS 2019 Workshop VRDIP Submission' == invitation_panel.find_element_by_class_name('btn').text
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('your-consoles')
+        assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
+        console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
+        assert 'Author Console' == console.find_element_by_tag_name('a').text
+        assert tabs.find_element_by_id('recent-activity')
+        assert len(tabs.find_element_by_id('recent-activity').find_elements_by_class_name('activity-list')) == 1
+
+        request_page(selenium, "http://localhost:3000/group?id=icaps-conference.org/ICAPS/2019/Workshop/VRDIP/Authors", test_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('author-schedule')
+        assert tabs.find_element_by_id('author-tasks')
+        assert tabs.find_element_by_id('your-submissions')
+        papers = tabs.find_element_by_id('your-submissions').find_element_by_class_name('submissions-list')
+        assert len(papers.find_elements_by_class_name('note')) == 1
+
+        conference.close_submissions()
+
+        blind_submissions = conference.create_blind_submissions()
+        assert blind_submissions
+        assert len(blind_submissions) == 1
+
+        guest_client = openreview.Client()
+
+        request_page(selenium, "http://localhost:3000/group?id=icaps-conference.org/ICAPS/2019/Workshop/VRDIP", guest_client.token)
+        invitation_panel = selenium.find_element_by_id('invitation')
+        assert invitation_panel
+        assert len(invitation_panel.find_elements_by_tag_name('div')) == 0
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        submissions = tabs.find_element_by_id('all-submissions')
+        assert submissions
+        assert len(submissions.find_elements_by_class_name('submissions-list')) == 1
+        assert len(submissions.find_elements_by_class_name('note-authors')) == 1
+        authors = submissions.find_elements_by_class_name('note-authors')[0]
+        assert 'Anonymous' == authors.text
+        
+
+
+
+
+
+
+        

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,11 +10,11 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 2, "Invitations could not be retrieved"
+        assert len(invitations) == 3, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)
-        assert len(venues) == 6, "Venues could not be retrieved"
+        assert len(venues) == 7, "Venues could not be retrieved"
 
     def test_iterget_notes(self, client):
         notes_iterator = openreview.tools.iterget_notes(client)


### PR DESCRIPTION
You can run this test to verify how it works:


tests/test_optional_double_blind.py

I want to keep the same field name for all the conferences and the builder will check the existence of this field to decide if overrides the author identities or not. 

Depending the setting set_submission_public is True or False, the field represents to reveal the identity to everyone or to the review committee. We could try to customize the field value to make this distinction. 