### PR TITLE
create blind submissions different times and get the same result

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -300,14 +300,15 @@ class Conference(object):
         if not self.double_blind:
             raise openreview.OpenReviewException('Conference is not double blind')
 
-        if next(self.get_submissions(), None):
-            raise openreview.OpenReviewException('Blind submissions already created')
+        submissions_by_original = { note.original: note.id for note in self.get_submissions() }
 
         self.invitation_builder.set_blind_submission_invitation(self)
         blinded_notes = []
 
         for note in tools.iterget_notes(self.client, invitation = self.get_submission_id(), sort = 'number:asc'):
+            note_id = submissions_by_original.get(note.id)
             blind_note = openreview.Note(
+                id = note_id,
                 original= note.id,
                 invitation= self.get_blind_submission_id(),
                 forum=None,

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -614,7 +614,7 @@ class TestDoubleBlindConference():
         assert builder, 'builder is None'
 
         builder.set_conference_id('AKBC.ws/2019/Conference')
-        builder.set_submission_public(True)
+        builder.set_submission_public(False)
         conference = builder.get_result()
 
         with pytest.raises(openreview.OpenReviewException, match=r'Conference is not double blind'):
@@ -627,8 +627,23 @@ class TestDoubleBlindConference():
         assert blind_submissions
         assert len(blind_submissions) == 1
 
-        with pytest.raises(openreview.OpenReviewException, match=r'Blind submissions already created'):
-            conference.create_blind_submissions()
+        blind_submissions_2 = conference.create_blind_submissions()
+        assert blind_submissions_2
+        assert len(blind_submissions_2) == 1
+        assert blind_submissions[0].id == blind_submissions_2[0].id
+        assert blind_submissions_2[0].readers == ['AKBC.ws/2019/Conference/Program_Chairs',
+         'AKBC.ws/2019/Conference/Area_Chairs', 
+         'AKBC.ws/2019/Conference/Reviewers', 
+         'AKBC.ws/2019/Conference/Paper1/Authors']
+
+        builder.set_submission_public(True)
+        conference = builder.get_result()
+        blind_submissions_3 = conference.create_blind_submissions()
+        assert blind_submissions_3
+        assert len(blind_submissions_3) == 1
+        assert blind_submissions[0].id == blind_submissions_3[0].id
+        assert blind_submissions_3[0].readers == ['everyone']       
+
 
     def test_open_comments(self, client, test_client, selenium, request_page):
 


### PR DESCRIPTION
Now we can call create_blind_submissions as many times we want and there won't be duplicates. Also if we change the conference settings the blind submissions will be updated. Take a look at the test. 