### PR TITLE
Create a Conference instance based on a request form note id

### DIFF
--- a/openreview/conference/__init__.py
+++ b/openreview/conference/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from .builder import *
 from .webfield import *
+from .helpers import *

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -13,6 +13,7 @@ class Conference(object):
 
     def __init__(self, client):
         self.client = client
+        self.new = False
         self.double_blind = False
         self.submission_public = False
         self.use_area_chairs = False
@@ -112,6 +113,9 @@ class Conference(object):
 
     def get_id(self):
         return self.id
+
+    def is_new(self):
+        return self.new
 
     def set_name(self, name):
         self.name = name
@@ -616,6 +620,7 @@ class ConferenceBuilder(object):
                     signatures = ['~Super_User1'],
                     members = [])
                 )
+                self.conference.new = True
 
             groups.append(group)
 

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -1,0 +1,69 @@
+import openreview
+import datetime
+
+def get_conference(client, request_form_id):
+
+    note = client.get_note(request_form_id)
+
+    if note.invitation not in 'OpenReview.net/Support/-/Request_Form':
+        raise openreview.OpenReviewException('Invalid request form invitation')
+
+    if not note.content.get('conference_id'):
+        raise openreview.OpenReviewException('conference_id is not set')
+
+    builder = openreview.conference.ConferenceBuilder(client)
+
+    conference_start_date_str = 'TBD'
+    if note.content.get('Conference Start Date'):
+        try:
+            conference_start_date = datetime.datetime.strptime(note.content.get('Conference Start Date'), '%Y/%m/%d %H:%M')
+        except ValueError:
+            conference_start_date = datetime.datetime.strptime(note.content.get('Conference Start Date'), '%Y/%m/%d')
+        conference_start_date_str = conference_start_date.strftime('%b %d %Y')
+
+    submission_start_date_str = ''
+    submission_start_date = None
+    if note.content.get('Submission Start Date'):
+        try:
+            submission_start_date = datetime.datetime.strptime(note.content.get('Submission Start Date'), '%Y/%m/%d %H:%M')
+        except ValueError:
+            submission_start_date = datetime.datetime.strptime(note.content.get('Submission Start Date'), '%Y/%m/%d')
+        submission_start_date_str = submission_start_date.strftime('%b %d %Y %I:%M%p')
+
+    submission_due_date_str = 'TBD'
+    submission_due_date = None
+    if note.content.get('Submission Deadline'):
+        try:
+            submission_due_date = datetime.datetime.strptime(note.content.get('Submission Deadline'), '%Y/%m/%d %H:%M')
+        except ValueError:
+            submission_due_date = datetime.datetime.strptime(note.content.get('Submission Deadline'), '%Y/%m/%d')
+        submission_due_date_str = submission_due_date.strftime('%b %d %Y %I:%M%p')
+
+    builder.set_conference_id(note.content['conference_id'])
+    builder.set_conference_name(note.content['Official Conference Name'])
+    builder.set_conference_short_name(note.content['Abbreviated Conference Name'])
+    builder.set_homepage_header({
+    'title': note.content['title'],
+    'subtitle': note.content['Abbreviated Conference Name'],
+    'deadline': 'Submission Start: ' + submission_start_date_str + ', End: ' + submission_due_date_str,
+    'date': conference_start_date_str,
+    'website': note.content['Official Website URL'],
+    'location': note.content.get('Conference Location')
+    })
+
+    if 'Yes, our conference has Area Chairs' == note.content.get('Area Chairs (Metareviewers)', ''):
+        builder.has_area_chairs(True)
+
+    if 'Double-blind' == note.content.get('Author and Reviewer Anonymity', ''):
+        builder.set_double_blind(True)
+
+    if 'Submissions and reviews should both be public.' == note.content.get('Open Reviewing Policy', '') or \
+        'Submissions should be public, but reviews should be private.' == note.content.get('Open Reviewing Policy', '') :
+        builder.set_submission_public(True)
+
+
+    builder.set_override_homepage(True)
+    conference = builder.get_result()
+    conference.open_submissions(start_date = submission_start_date, due_date = submission_due_date)
+    conference.set_program_chairs(emails = note.content['Contact Emails'])
+    return conference

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -38,7 +38,7 @@ class SubmissionInvitation(openreview.Invitation):
             super(SubmissionInvitation, self).__init__(id = conference.get_submission_id(),
                 cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
-                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
+                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)) if due_date else None,
                 readers = ['everyone'],
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],


### PR DESCRIPTION
We shouldn't use the config.py file anymore to set up a new venue. Use the request from note id instead. 

If some part of the configuration is not present in the request from note then we should add these missing data as a revision. 

If the configuration is too specific, you can keep using a python script, but instead of doing this:

```
conference = config.get_conference(client)
```

you should do:

```
conference = openreview.helpers.get_conference(client, [note_id])
```