### PR TITLE
Fix/unassign reviewer

### DIFF
--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -839,6 +839,8 @@ def remove_assignment(client, paper_number, conference, reviewer,
 
     user_groups = [g.id for g in client.get_groups(member=user)]
     user_groups.append(user)
+    if ('@' in reviewer) and (reviewer not in user_groups):
+        user_groups.append(reviewer)
 
     affected_groups = set()
 
@@ -851,7 +853,7 @@ def remove_assignment(client, paper_number, conference, reviewer,
         for individual_group in assigned_individual_groups:
             affected_groups.add(individual_group.id)
             client.remove_members_from_group(individual_group, user_entity)
-    return (user,list(affected_groups))
+    return (user, list(affected_groups))
 
 
 def assign(client, paper_number, conference,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='0.9.15',
+      version='0.9.16',
       description='OpenReview client library',
       url='https://github.com/iesl/openreview-py',
       author='Michael Spector, Melisa Bok, Pam Mander, Mohit Uniyal',


### PR DESCRIPTION
While finding individual groups with the reviewer as a member, currently we look for the profile id, if found. With this change we will look for email even if the profile id is found. This is needed because at times reviewer groups are created with emails as members but then the user registers with the email later, thus creating a profile.