### PR TITLE
Feature/invitation id refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: install and run app
           command: |
             cd ~/openreview
-            npm install
+            npm install --production
             sudo npm install -g grunt-cli
             grunt regen
             mkdir pdfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: install and run app
           command: |
             cd ~/openreview
-            npm install --production
+            npm install
             sudo npm install -g grunt-cli
             grunt regen
             mkdir pdfs
@@ -72,7 +72,7 @@ jobs:
           name: install and run app
           command: |
             cd ~/openreview
-            npm install --production
+            npm install
             sudo npm install -g grunt-cli
             grunt regen
             mkdir pdfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           name: install and run app
           command: |
             cd ~/openreview
-            npm install
+            npm install --production
             sudo npm install -g grunt-cli
             grunt regen
             mkdir pdfs

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -418,7 +418,7 @@ class Conference(object):
     def close_comments(self, name):
         return self.__expire_invitations(name)
 
-    def open_reviews(self, name = 'Official_Review', start_date = None, due_date = None, allow_de_anonymization = False, public = False, release_to_authors = False, release_to_reviewers = False, email_pcs = False, additional_fields = {}):
+    def open_reviews(self, start_date = None, due_date = None, allow_de_anonymization = False, public = False, release_to_authors = False, release_to_reviewers = False, email_pcs = False, additional_fields = {}):
         """
         Create review invitations for all the available submissions.
 
@@ -432,31 +432,31 @@ class Conference(object):
         :arg additional_fields: field to add/overwrite to the review invitation
         """
         notes = list(self.get_submissions())
-        invitations = self.invitation_builder.set_review_invitation(self, notes, name, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields)
+        invitations = self.invitation_builder.set_review_invitation(self, notes, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields)
         ## Create submitted groups if they don't exist
         for n in notes:
             self.__create_group(self.get_id() + '/Paper{}/Reviewers/Submitted'.format(n.number), self.get_program_chairs_id())
         return invitations
 
-    def close_reviews(self, name = 'Official_Review'):
-        return self.__expire_invitations(name)
+    def close_reviews(self):
+        return self.__expire_invitations(self.review_name)
 
-    def open_meta_reviews(self, name = 'Meta_Review', start_date = None, due_date = None, public = False):
+    def open_meta_reviews(self, start_date = None, due_date = None, public = False):
         notes_iterator = self.get_submissions()
-        return self.invitation_builder.set_meta_review_invitation(self, notes_iterator, name, start_date, due_date, public)
+        return self.invitation_builder.set_meta_review_invitation(self, notes_iterator, start_date, due_date, public)
 
-    def open_decisions(self, name = 'Decision', options = ['Accept (Oral)', 'Accept (Poster)', 'Reject'], start_date = None, due_date = None, public = False, release_to_authors = False, release_to_reviewers = False):
+    def open_decisions(self, options = ['Accept (Oral)', 'Accept (Poster)', 'Reject'], start_date = None, due_date = None, public = False, release_to_authors = False, release_to_reviewers = False):
         notes_iterator = self.get_submissions()
-        return self.invitation_builder.set_decision_invitation(self, notes_iterator, name, options, start_date, due_date, public, release_to_authors, release_to_reviewers)
+        return self.invitation_builder.set_decision_invitation(self, notes_iterator, options, start_date, due_date, public, release_to_authors, release_to_reviewers)
 
     def open_revise_submissions(self, name = 'Revision', start_date = None, due_date = None, additional_fields = {}, remove_fields = []):
         invitation = self.client.get_invitation(self.get_submission_id())
         notes_iterator = self.get_submissions()
         return self.invitation_builder.set_revise_submission_invitation(self, notes_iterator, name, start_date, due_date, invitation.reply['content'], additional_fields, remove_fields)
 
-    def open_revise_reviews(self, name = 'Revision', review_name = 'Official_Review', start_date = None, due_date = None, additional_fields = {}, remove_fields = []):
+    def open_revise_reviews(self, name = 'Revision', start_date = None, due_date = None, additional_fields = {}, remove_fields = []):
 
-        invitation = self.get_invitation_id(review_name, '.*')
+        invitation = self.get_invitation_id(self.review_name, '.*')
         review_iterator = tools.iterget_notes(self.client, invitation = invitation)
         return self.invitation_builder.set_revise_review_invitation(self, review_iterator, name, start_date, due_date, additional_fields, remove_fields)
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -39,6 +39,7 @@ class Conference(object):
         self.registration_name = 'Registration'
         self.review_name = 'Official_Review'
         self.meta_review_name = 'Meta_Review'
+        self.decision_name = 'Decision'
         self.layout = 'tabs'
 
     def __create_group(self, group_id, group_owner_id, members = []):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -17,6 +17,7 @@ class Conference(object):
         self.double_blind = False
         self.submission_public = False
         self.use_area_chairs = False
+        self.legacy_invitation_id = False
         self.original_readers = []
         self.subject_areas = []
         self.groups = []
@@ -197,9 +198,14 @@ class Conference(object):
     def get_invitation_id(self, name, number = None):
         invitation_id = self.id
         if number:
-            invitation_id = invitation_id + '/Paper' + str(number)
+            if self.legacy_invitation_id:
+                invitation_id = invitation_id + '/-/Paper' + str(number) + '/'
+            else:
+                invitation_id = invitation_id + '/Paper' + str(number) + '/-/'
+        else:
+            invitation_id = invitation_id + '/-/'
 
-        invitation_id = invitation_id + '/-/' + name
+        invitation_id =  invitation_id + name
         return invitation_id
 
     def set_conference_groups(self, groups):
@@ -707,6 +713,18 @@ class ConferenceBuilder(object):
 
     def has_area_chairs(self, has_area_chairs):
         self.conference.has_area_chairs(has_area_chairs)
+
+    def set_review_name(self, review_name):
+        self.conference.review_name = review_name
+
+    def set_meta_review_name(self, meta_review_name):
+        self.conference.meta_review_name = meta_review_name
+
+    def set_decision_name(self, decision_name):
+        self.conference.decision_name = decision_name
+
+    def use_legacy_invitation_id(self, legacy_invitation_id):
+        self.conference.legacy_invitation_id = legacy_invitation_id
 
     def get_result(self):
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -37,6 +37,8 @@ class Conference(object):
         self.bid_name = 'Bid'
         self.recommendation_name = 'Recommendation'
         self.registration_name = 'Registration'
+        self.review_name = 'Official_Review'
+        self.meta_review_name = 'Meta_Review'
         self.layout = 'tabs'
 
     def __create_group(self, group_id, group_owner_id, members = []):
@@ -448,7 +450,6 @@ class Conference(object):
     def open_revise_reviews(self, name = 'Revision', review_name = 'Official_Review', start_date = None, due_date = None, additional_fields = {}, remove_fields = []):
 
         invitation = self.get_invitation_id(review_name, '.*')
-        print('INVITATION', invitation)
         review_iterator = tools.iterget_notes(self.client, invitation = invitation)
         return self.invitation_builder.set_revise_review_invitation(self, review_iterator, name, start_date, due_date, additional_fields, remove_fields)
 
@@ -520,7 +521,7 @@ class Conference(object):
                     self.get_program_chairs_id(),
                     self.get_area_chairs_id(number = number)
                 ]
-            })
+            }, use_profile = True)
 
     def set_assignments(self, assingment_title):
         conference_matching = matching.Matching(self)

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -327,7 +327,7 @@ class OfficialCommentInvitation(openreview.Invitation):
 
 class ReviewInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, note, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields):
+    def __init__(self, conference, note, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields):
         content = invitations.review.copy()
 
         for key in additional_fields:
@@ -370,7 +370,7 @@ class ReviewInvitation(openreview.Invitation):
             if email_pcs:
                 file_content = file_content.replace("var PROGRAM_CHAIRS_NAME = '';", "var PROGRAM_CHAIRS_NAME = '" + conference.program_chairs_name + "';")
 
-            super(ReviewInvitation, self).__init__(id = conference.get_invitation_id(name, note.number),
+            super(ReviewInvitation, self).__init__(id = conference.get_invitation_id(conference.review_name, note.number),
                 cdate = tools.datetime_millis(start_date),
                 duedate = tools.datetime_millis(due_date),
                 expdate = tools.datetime_millis(due_date + datetime.timedelta(days = LONG_BUFFER_DAYS)) if due_date else None,
@@ -431,7 +431,7 @@ class ReviewRevisionInvitation(openreview.Invitation):
 
 class MetaReviewInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, note, start_date, due_date, public):
+    def __init__(self, conference, note, start_date, due_date, public):
         content = invitations.meta_review.copy()
 
         readers = ['everyone']
@@ -447,7 +447,7 @@ class MetaReviewInvitation(openreview.Invitation):
         if not public:
             readers = private_readers
 
-        super(MetaReviewInvitation, self).__init__(id = conference.get_invitation_id(name, note.number),
+        super(MetaReviewInvitation, self).__init__(id = conference.get_invitation_id(conference.meta_review_name, note.number),
             cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             expdate = tools.datetime_millis(due_date + datetime.timedelta(days = LONG_BUFFER_DAYS)) if due_date else None,
@@ -476,7 +476,7 @@ class MetaReviewInvitation(openreview.Invitation):
 
 class DecisionInvitation(openreview.Invitation):
 
-    def __init__(self, conference, name, note, options, start_date, due_date, public, release_to_authors, release_to_reviewers):
+    def __init__(self, conference, note, options, start_date, due_date, public, release_to_authors, release_to_reviewers):
         content = {
             'title': {
                 'order': 1,
@@ -515,7 +515,7 @@ class DecisionInvitation(openreview.Invitation):
             readers.append(conference.get_authors_id(number = note.number))
             nonreaders = []
 
-        super(DecisionInvitation, self).__init__(id = conference.get_invitation_id(name, note.number),
+        super(DecisionInvitation, self).__init__(id = conference.get_invitation_id(conference.decision_name, note.number),
             cdate = tools.datetime_millis(start_date),
             duedate = tools.datetime_millis(due_date),
             expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = LONG_BUFFER_DAYS)) if due_date else None,
@@ -619,24 +619,24 @@ class InvitationBuilder(object):
         for note in notes:
             self.client.post_invitation(OfficialCommentInvitation(conference, name, note, start_date, anonymous, unsubmitted_reviewers, reader_selection, email_pcs))
 
-    def set_review_invitation(self, conference, notes, name, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields):
+    def set_review_invitation(self, conference, notes, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields):
 
         invitations = []
         for note in notes:
-            invitations.append(self.client.post_invitation(ReviewInvitation(conference, name, note, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields)))
+            invitations.append(self.client.post_invitation(ReviewInvitation(conference, note, start_date, due_date, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields)))
 
         return invitations
 
 
-    def set_meta_review_invitation(self, conference, notes, name, start_date, due_date, public):
+    def set_meta_review_invitation(self, conference, notes, start_date, due_date, public):
 
         for note in notes:
-            self.client.post_invitation(MetaReviewInvitation(conference, name, note, start_date, due_date, public))
+            self.client.post_invitation(MetaReviewInvitation(conference, note, start_date, due_date, public))
 
-    def set_decision_invitation(self, conference, notes, name, options, start_date, due_date, public, release_to_authors, release_to_reviewers):
+    def set_decision_invitation(self, conference, notes, options, start_date, due_date, public, release_to_authors, release_to_reviewers):
 
         for note in notes:
-            self.client.post_invitation(DecisionInvitation(conference, name, note, options, start_date, due_date, public, release_to_authors, release_to_reviewers))
+            self.client.post_invitation(DecisionInvitation(conference, note, options, start_date, due_date, public, release_to_authors, release_to_reviewers))
 
     def set_revise_submission_invitation(self, conference, notes, name, start_date, due_date, submission_content, additional_fields, remove_fields):
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -788,7 +788,7 @@ class InvitationBuilder(object):
                 duedate = tools.datetime_millis(due_date),
                 expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
                 super = recommendation_invitation.id,
-                invitees = [conference.get_program_chairs_id(), conference.get_id() + '/Paper{number}/Area_Chairs'.format(number = note.number)],
+                invitees = [conference.get_program_chairs_id(), conference.get_area_chairs_id(note.number)],
                 writers = [conference.get_id()],
                 signatures = [conference.get_id()],
                 multiReply = True,

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -404,7 +404,6 @@ class ReviewInvitation(openreview.Invitation):
 class ReviewRevisionInvitation(openreview.Invitation):
 
     def __init__(self, conference, name, review, start_date, due_date, additional_fields, remove_fields):
-        print('REVISE_INVITATION', start_date, due_date)
         with open(os.path.join(os.path.dirname(__file__), 'templates/reviewRevisionProcess.js')) as f:
             file_content = f.read()
 

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -231,7 +231,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       revIds[revNumber] = _.get(profiles, uId, { id: uId, name: '', email: uId });
     }
 
-    var metaReview = _.find(metaReviews, ['invitation', getInvitationId('Meta_Review', note.number)]);
+    var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, note.number)]);
     var noteCompletedReviews = completedReviews[note.number] || Object.create(null);
 
     return buildTableRow(note, revIds, noteCompletedReviews, metaReview);
@@ -296,7 +296,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
         var forumUrl = 'https://openreview.net/forum?' + $.param({
           id: row[2].forum,
           noteId: row[2].id,
-          invitationId: getInvitationId('Official_Review', row[2].number)
+          invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, row[2].number)
         });
         reviewerMessages.push({
           groups: _.map(users, 'id'),
@@ -526,7 +526,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
       var forumUrl = 'https://openreview.net/forum?' + $.param({
         id: note.forum,
         noteId: note.id,
-        invitationId: getInvitationId('Official_Review', note.number)
+        invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
       });
       var lastReminderSent = localStorage.getItem(forumUrl + '|' + reviewer.id);
       combinedObj[reviewerNum] = {

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -7,6 +7,7 @@ var HEADER = {};
 var AREA_CHAIR_NAME = '';
 var OFFICIAL_REVIEW_NAME = '';
 var OFFICIAL_META_REVIEW_NAME = '';
+var LEGACY_INVITATION_ID = false;
 
 var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
@@ -57,6 +58,9 @@ var buildNoteMap = function(noteNumbers) {
 };
 
 var getInvitationId = function(name, number) {
+  if (LEGACY_INVITATION_ID) {
+    return CONFERENCE_ID + '/-/Paper' + number + '/' + name;
+  }
   return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
 }
 

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -6,9 +6,9 @@ var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var AREA_CHAIR_NAME = '';
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/-/Paper.*/Official_Review';
-var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/-/Paper.*/Meta_Review';
-var WILDCARD_INVITATION = CONFERENCE_ID + '/-/.*';
+var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
+var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Meta_Review';
+var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 var AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Area_Chair.*';
 
@@ -228,7 +228,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       revIds[revNumber] = _.get(profiles, uId, { id: uId, name: '', email: uId });
     }
 
-    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/-/Paper' + note.number + '/Meta_Review']);
+    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review']);
     var noteCompletedReviews = completedReviews[note.number] || Object.create(null);
 
     return buildTableRow(note, revIds, noteCompletedReviews, metaReview);
@@ -293,7 +293,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
         var forumUrl = 'https://openreview.net/forum?' + $.param({
           id: row[2].forum,
           noteId: row[2].id,
-          invitationId: CONFERENCE_ID + '/-/Paper' + row[2].number + '/Official_Review'
+          invitationId: CONFERENCE_ID + '/Paper' + row[2].number + '/-/Official_Review'
         });
         reviewerMessages.push({
           groups: _.map(users, 'id'),
@@ -523,7 +523,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
       var forumUrl = 'https://openreview.net/forum?' + $.param({
         id: note.forum,
         noteId: note.id,
-        invitationId: CONFERENCE_ID + '/-/Paper' + note.number + '/Official_Review'
+        invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
       });
       var lastReminderSent = localStorage.getItem(forumUrl + '|' + reviewer.id);
       combinedObj[reviewerNum] = {
@@ -572,7 +572,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
   var invitationUrlParams = {
     id: note.forum,
     noteId: note.id,
-    invitationId: CONFERENCE_ID + '/-/Paper' + note.number + '/Meta_Review'
+    invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review'
   };
   var cell5 = {
     invitationUrl: '/forum?' + $.param(invitationUrlParams)

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -5,9 +5,9 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var AREA_CHAIR_NAME = '';
+var OFFICIAL_REVIEW_NAME = '';
+var OFFICIAL_META_REVIEW_NAME = '';
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
-var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Meta_Review';
 var WILDCARD_INVITATION = CONFERENCE_ID + '.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 var AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Area_Chair.*';
@@ -56,6 +56,9 @@ var buildNoteMap = function(noteNumbers) {
   return noteMap;
 };
 
+var getInvitationId = function(name, number) {
+  return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
+}
 
 // Ajax functions
 var loadData = function(result) {
@@ -71,7 +74,7 @@ var loadData = function(result) {
     });
 
     metaReviewsP = Webfield.getAll('/notes', {
-      invitation: OFFICIAL_META_REVIEW_INVITATION, noDetails: true
+      invitation: getInvitationId(OFFICIAL_META_REVIEW_NAME, '.*'), noDetails: true
     });
   } else {
     blindedNotesP = $.Deferred().resolve([]);
@@ -109,7 +112,7 @@ var getOfficialReviews = function(noteNumbers) {
   var noteMap = buildNoteMap(noteNumbers);
 
   return Webfield.getAll('/notes', {
-    invitation: OFFICIAL_REVIEW_INVITATION, noDetails: true
+    invitation: getInvitationId(OFFICIAL_REVIEW_NAME, '.*'), noDetails: true
   })
   .then(function(notes) {
     var ratingExp = /^(\d+): .*/;
@@ -228,7 +231,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       revIds[revNumber] = _.get(profiles, uId, { id: uId, name: '', email: uId });
     }
 
-    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review']);
+    var metaReview = _.find(metaReviews, ['invitation', getInvitationId('Meta_Review', note.number)]);
     var noteCompletedReviews = completedReviews[note.number] || Object.create(null);
 
     return buildTableRow(note, revIds, noteCompletedReviews, metaReview);
@@ -293,7 +296,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
         var forumUrl = 'https://openreview.net/forum?' + $.param({
           id: row[2].forum,
           noteId: row[2].id,
-          invitationId: CONFERENCE_ID + '/Paper' + row[2].number + '/-/Official_Review'
+          invitationId: getInvitationId('Official_Review', row[2].number)
         });
         reviewerMessages.push({
           groups: _.map(users, 'id'),
@@ -523,7 +526,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
       var forumUrl = 'https://openreview.net/forum?' + $.param({
         id: note.forum,
         noteId: note.id,
-        invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
+        invitationId: getInvitationId('Official_Review', note.number)
       });
       var lastReminderSent = localStorage.getItem(forumUrl + '|' + reviewer.id);
       combinedObj[reviewerNum] = {
@@ -572,7 +575,7 @@ var buildTableRow = function(note, reviewerIds, completedReviews, metaReview) {
   var invitationUrlParams = {
     id: note.forum,
     noteId: note.id,
-    invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review'
+    invitationId: getInvitationId('Meta_Review', note.number)
   };
   var cell5 = {
     invitationUrl: '/forum?' + $.param(invitationUrlParams)

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -55,7 +55,7 @@ function load() {
     });
 
     invitationsP = Webfield.get('/invitations', {
-      regex: CONFERENCE_ID + '/-/.*',
+      regex: CONFERENCE_ID + '.*',
       invitee: true,
       duedate: true,
       replyto: true,
@@ -65,7 +65,7 @@ function load() {
     });
 
     tagInvitationsP = Webfield.get('/invitations', {
-      regex: CONFERENCE_ID + '/-/.*',
+      regex: CONFERENCE_ID + '.*',
       invitee: true,
       duedate: true,
       tags: true,

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -5,6 +5,7 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var SHOW_AC_TAB = false;
+var LEGACY_INVITATION_ID = false;
 var OFFICIAL_REVIEW_NAME = '';
 var OFFICIAL_META_REVIEW_NAME = '';
 var DECISION_NAME = '';
@@ -32,6 +33,9 @@ var getPaperNumbersfromGroups = function(groups) {
 };
 
 var getInvitationId = function(name, number) {
+  if (LEGACY_INVITATION_ID) {
+    return CONFERENCE_ID + '/-/Paper' + number + '/' + name;
+  }
   return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
 }
 

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -6,10 +6,10 @@ var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var SHOW_AC_TAB = false;
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/-/Paper.*/Official_Review';
-var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/-/Paper.*/Meta_Review';
-var OFFICIAL_DECISION_INVITATION = CONFERENCE_ID + '/-/Paper.*/Decision';
-var WILDCARD_INVITATION = CONFERENCE_ID + '/-/.*';
+var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
+var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Meta_Review';
+var OFFICIAL_DECISION_INVITATION = CONFERENCE_ID + '/Paper.*/-/Decision';
+var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 var AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Area_Chairs';
 
@@ -285,11 +285,11 @@ var displayPaperStatusTable = function(profiles, notes, completedReviews, metaRe
     if (areachairId) {
       areachairProfile = findProfile(profiles, areachairId);
     } else {
-      areachairProfile.name = view.prettyId(CONFERENCE_ID + '/-/Paper' + note.number + '/Area_Chair');
+      areachairProfile.name = view.prettyId(CONFERENCE_ID + '/Paper' + note.number + '/-/Area_Chair');
       areachairProfile.email = '-';
     }
-    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/-/Paper' + note.number + '/Meta_Review']);
-    var decision = _.find(decisions, ['invitation', CONFERENCE_ID + '/-/Paper' + note.number + '/Decision']);
+    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review']);
+    var decision = _.find(decisions, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Decision']);
     return buildPaperTableRow(note, revIds, completedReviews[note.number], metaReview, areachairProfile, decision);
   });
 
@@ -373,7 +373,7 @@ var displaySPCStatusTable = function(profiles, notes, completedReviews, metaRevi
       if (note) {
         var reviewers = reviewerIds[number];
         var reviews = completedReviews[number];
-        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/-/Paper' + number + '/Meta_Review']);
+        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + number + '/-/Meta_Review']);
 
         papers.push({
           note: note,
@@ -473,7 +473,7 @@ var displayPCStatusTable = function(profiles, notes, completedReviews, metaRevie
 
         var reviews = completedReviews[number];
         var review = reviews[reviewerNum] || findReview(reviews, reviewerProfile);
-        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/-/Paper' + number + '/Meta_Review']);
+        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + number + '/-/Meta_Review']);
 
         papers.push({
           note: note,
@@ -570,7 +570,7 @@ var buildPaperTableRow = function(note, reviewerIds, completedReviews, metaRevie
         forumUrl: '/forum?' + $.param({
           id: note.forum,
           noteId: note.id,
-          invitationId: CONFERENCE_ID + '/-/Paper' + note.number + '/Official_Review'
+          invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
         })
       });
     }

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -5,10 +5,10 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var SHOW_AC_TAB = false;
+var OFFICIAL_REVIEW_NAME = '';
+var OFFICIAL_META_REVIEW_NAME = '';
+var DECISION_NAME = '';
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
-var OFFICIAL_META_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Meta_Review';
-var OFFICIAL_DECISION_INVITATION = CONFERENCE_ID + '/Paper.*/-/Decision';
 var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 var AREACHAIR_WILDCARD = CONFERENCE_ID + '/Paper.*/Area_Chairs';
@@ -31,6 +31,10 @@ var getPaperNumbersfromGroups = function(groups) {
   }), _.isInteger);
 };
 
+var getInvitationId = function(name, number) {
+  return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
+}
+
 var getBlindedNotes = function() {
   return Webfield.getAll('/notes', {
     invitation: BLIND_SUBMISSION_ID, noDetails: true
@@ -45,7 +49,7 @@ var getOfficialReviews = function(noteNumbers) {
   var noteMap = buildNoteMap(noteNumbers);
 
   return Webfield.getAll('/notes', {
-    invitation: OFFICIAL_REVIEW_INVITATION, noDetails: true
+    invitation: getInvitationId(OFFICIAL_REVIEW_NAME, '.*'), noDetails: true
   })
   .then(function(notes) {
     var ratingExp = /^(\d+): .*/;
@@ -200,13 +204,13 @@ var findProfile = function(profiles, id) {
 
 var getMetaReviews = function() {
   return Webfield.getAll('/notes', {
-    invitation: OFFICIAL_META_REVIEW_INVITATION, noDetails: true
+    invitation: getInvitationId(OFFICIAL_META_REVIEW_NAME, '.*'), noDetails: true
   });
 };
 
 var getDecisionReviews = function() {
   return Webfield.getAll('/notes', {
-    invitation: OFFICIAL_DECISION_INVITATION, noDetails: true
+    invitation: getInvitationId(DECISION_NAME, '.*'), noDetails: true
   });
 };
 
@@ -285,11 +289,11 @@ var displayPaperStatusTable = function(profiles, notes, completedReviews, metaRe
     if (areachairId) {
       areachairProfile = findProfile(profiles, areachairId);
     } else {
-      areachairProfile.name = view.prettyId(CONFERENCE_ID + '/Paper' + note.number + '/-/Area_Chair');
+      areachairProfile.name = view.prettyId(CONFERENCE_ID + '/Paper' + note.number + '/Area_Chairs');
       areachairProfile.email = '-';
     }
-    var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Meta_Review']);
-    var decision = _.find(decisions, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Decision']);
+    var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, note.number)]);
+    var decision = _.find(decisions, ['invitation', getInvitationId(DECISION_NAME, note.number)]);
     return buildPaperTableRow(note, revIds, completedReviews[note.number], metaReview, areachairProfile, decision);
   });
 
@@ -373,7 +377,7 @@ var displaySPCStatusTable = function(profiles, notes, completedReviews, metaRevi
       if (note) {
         var reviewers = reviewerIds[number];
         var reviews = completedReviews[number];
-        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + number + '/-/Meta_Review']);
+        var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, number)]);
 
         papers.push({
           note: note,
@@ -473,7 +477,7 @@ var displayPCStatusTable = function(profiles, notes, completedReviews, metaRevie
 
         var reviews = completedReviews[number];
         var review = reviews[reviewerNum] || findReview(reviews, reviewerProfile);
-        var metaReview = _.find(metaReviews, ['invitation', CONFERENCE_ID + '/Paper' + number + '/-/Meta_Review']);
+        var metaReview = _.find(metaReviews, ['invitation', getInvitationId(OFFICIAL_META_REVIEW_NAME, number)]);
 
         papers.push({
           note: note,
@@ -570,7 +574,7 @@ var buildPaperTableRow = function(note, reviewerIds, completedReviews, metaRevie
         forumUrl: '/forum?' + $.param({
           id: note.forum,
           noteId: note.id,
-          invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
+          invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
         })
       });
     }

--- a/openreview/conference/templates/recommendationWebfield.js
+++ b/openreview/conference/templates/recommendationWebfield.js
@@ -47,7 +47,7 @@ function load() {
     }
 
     var tagInvitationsP = Webfield.getAll('/invitations', {
-      regex: CONFERENCE_ID + '/-/Paper.*/Recommendation', tags: true, invitee: true
+      regex: CONFERENCE_ID + '/Paper.*/-/Recommendation', tags: true, invitee: true
     });
 
     return $.when(notesP, tagInvitationsP);

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -6,8 +6,8 @@ var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var REVIEWER_NAME = '';
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/-/Paper.*/Official_Review';
-var WILDCARD_INVITATION = CONFERENCE_ID + '/-/.*';
+var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
+var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 
 // Ajax functions
@@ -42,7 +42,7 @@ var getBlindedNotes = function(noteNumbers) {
 };
 
 var getAllRatings = function(callback) {
-  var invitationId = CONFERENCE_ID + '/-/Paper.*/Review_Rating';
+  var invitationId = CONFERENCE_ID + '/Paper.*/-/Review_Rating';
   var allNotes = [];
 
   function getPromise(offset, limit) {
@@ -222,7 +222,7 @@ var displayStatusTable = function(profiles, notes, completedRatings, officialRev
         revIds[revNumber] = profile;
       }
 
-      var officialReview = _.find(officialReviews, ['invitation', CONFERENCE_ID + '/-/Paper' + note.number + '/Official_Review']);
+      var officialReview = _.find(officialReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review']);
       return buildTableRow(
         note, revIds, completedRatings[note.number], officialReview
       );
@@ -280,7 +280,7 @@ var buildTableRow = function(note, reviewerIds, completedRatings, officialReview
   var invitationUrlParams = {
     id: note.forum,
     noteId: note.id,
-    invitationId: CONFERENCE_ID + '/-/Paper' + note.number + '/Official_Review'
+    invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
   };
   var reviewStatus = {
     invitationUrl: '/forum?' + $.param(invitationUrlParams),

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -5,8 +5,8 @@ var SUBMISSION_ID = '';
 var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var REVIEWER_NAME = '';
+var OFFICIAL_REVIEW_NAME = '';
 
-var OFFICIAL_REVIEW_INVITATION = CONFERENCE_ID + '/Paper.*/-/Official_Review';
 var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
 
@@ -28,6 +28,10 @@ var getPaperNumbersfromGroups = function(groups) {
   }), _.isInteger);
 };
 
+var getInvitationId = function(name, number) {
+  return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
+}
+
 var getBlindedNotes = function(noteNumbers) {
   if (!noteNumbers.length) {
     return $.Deferred().resolve([]);
@@ -42,7 +46,7 @@ var getBlindedNotes = function(noteNumbers) {
 };
 
 var getAllRatings = function(callback) {
-  var invitationId = CONFERENCE_ID + '/Paper.*/-/Review_Rating';
+  var invitationId = getInvitationId('Review_Rating', '.*');
   var allNotes = [];
 
   function getPromise(offset, limit) {
@@ -222,7 +226,7 @@ var displayStatusTable = function(profiles, notes, completedRatings, officialRev
         revIds[revNumber] = profile;
       }
 
-      var officialReview = _.find(officialReviews, ['invitation', CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review']);
+      var officialReview = _.find(officialReviews, ['invitation', getInvitationId(OFFICIAL_REVIEW_NAME, note.number)]);
       return buildTableRow(
         note, revIds, completedRatings[note.number], officialReview
       );
@@ -280,7 +284,7 @@ var buildTableRow = function(note, reviewerIds, completedRatings, officialReview
   var invitationUrlParams = {
     id: note.forum,
     noteId: note.id,
-    invitationId: CONFERENCE_ID + '/Paper' + note.number + '/-/Official_Review'
+    invitationId: getInvitationId(OFFICIAL_REVIEW_NAME, note.number)
   };
   var reviewStatus = {
     invitationUrl: '/forum?' + $.param(invitationUrlParams),

--- a/openreview/conference/templates/reviewerWebfield.js
+++ b/openreview/conference/templates/reviewerWebfield.js
@@ -6,6 +6,7 @@ var BLIND_SUBMISSION_ID = '';
 var HEADER = {};
 var REVIEWER_NAME = '';
 var OFFICIAL_REVIEW_NAME = '';
+var LEGACY_INVITATION_ID = false;
 
 var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var ANONREVIEWER_WILDCARD = CONFERENCE_ID + '/Paper.*/AnonReviewer.*';
@@ -29,6 +30,9 @@ var getPaperNumbersfromGroups = function(groups) {
 };
 
 var getInvitationId = function(name, number) {
+  if (LEGACY_INVITATION_ID) {
+    return CONFERENCE_ID + '/-/Paper' + number + '/' + name;
+  }
   return CONFERENCE_ID + '/Paper' + number + '/-/' + name;
 }
 
@@ -165,7 +169,7 @@ var getOfficialReviews = function(noteNumbers) {
     return $.Deferred().resolve({});
   }
 
-  return $.getJSON('notes', { invitation: OFFICIAL_REVIEW_INVITATION, tauthor: true, noDetails: true })
+  return $.getJSON('notes', { invitation: getInvitationId(OFFICIAL_REVIEW_NAME, '.*'), tauthor: true, noDetails: true })
     .then(function(result) {
       return result.notes;
     }).fail(function(error) {

--- a/openreview/conference/templates/tabsConferenceWebfield.js
+++ b/openreview/conference/templates/tabsConferenceWebfield.js
@@ -18,7 +18,7 @@ var AUTHORS_ID = '';
 
 var HEADER = {};
 
-var WILDCARD_INVITATION = CONFERENCE_ID + '/-/.*';
+var WILDCARD_INVITATION = CONFERENCE_ID + '/.*';
 var BUFFER = 0;  // deprecated
 var PAGE_SIZE = 50;
 
@@ -189,7 +189,7 @@ function renderContent(notes, userGroups, activityNotes, authorNotes) {
     container: '#all-submissions',
     queryParams: {
       details: 'replyCount,original'
-    }    
+    }
   });
 
   $(submissionListOptions.container).empty();

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -217,7 +217,7 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var REVIEWER_NAME = {};", "var REVIEWER_NAME = " + conference.reviewers_name + ";")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
-            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = true;" if conference.legacy_invitation_id else "var LEGACY_INVITATION_ID = false;")
             group.web = content
             return self.client.post_group(group)
 
@@ -247,7 +247,7 @@ class WebfieldBuilder(object):
             content = content.replace("var AREA_CHAIR_NAME = '';", "var AREA_CHAIR_NAME = '" + conference.area_chairs_name + "';")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
             content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
-            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = true;" if conference.legacy_invitation_id else "var LEGACY_INVITATION_ID = false;")
             group.web = content
             return self.client.post_group(group)
 
@@ -292,7 +292,7 @@ class WebfieldBuilder(object):
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
             content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
             content = content.replace("var DECISION_NAME = '';", "var DECISION_NAME = '" + conference.decision_name + "';")
-            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = true;" if conference.legacy_invitation_id else "var LEGACY_INVITATION_ID = false;")
             group.web = content
             return self.client.post_group(group)
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -216,6 +216,7 @@ class WebfieldBuilder(object):
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var REVIEWER_NAME = {};", "var REVIEWER_NAME = " + conference.reviewers_name + ";")
+            content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
             group.web = content
             return self.client.post_group(group)
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -286,6 +286,9 @@ class WebfieldBuilder(object):
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + submission_id + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var SHOW_AC_TAB = false;", "var SHOW_AC_TAB = true;" if conference.use_area_chairs else "var SHOW_AC_TAB = false;")
+            content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
+            content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
+            content = content.replace("var DECISION_NAME = '';", "var DECISION_NAME = '" + conference.decision_name + "';")
             group.web = content
             return self.client.post_group(group)
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -242,7 +242,9 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
-            content = content.replace("var AREA_CHAIR_NAME = {};", "var AREA_CHAIR_NAME = " + conference.area_chairs_name + ";")
+            content = content.replace("var AREA_CHAIR_NAME = '';", "var AREA_CHAIR_NAME = '" + conference.area_chairs_name + "';")
+            content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
+            content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
             group.web = content
             return self.client.post_group(group)
 

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -217,6 +217,7 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var REVIEWER_NAME = {};", "var REVIEWER_NAME = " + conference.reviewers_name + ";")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
             group.web = content
             return self.client.post_group(group)
 
@@ -246,6 +247,7 @@ class WebfieldBuilder(object):
             content = content.replace("var AREA_CHAIR_NAME = '';", "var AREA_CHAIR_NAME = '" + conference.area_chairs_name + "';")
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
             content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
             group.web = content
             return self.client.post_group(group)
 
@@ -290,6 +292,7 @@ class WebfieldBuilder(object):
             content = content.replace("var OFFICIAL_REVIEW_NAME = '';", "var OFFICIAL_REVIEW_NAME = '" + conference.review_name + "';")
             content = content.replace("var OFFICIAL_META_REVIEW_NAME = '';", "var OFFICIAL_META_REVIEW_NAME = '" + conference.meta_review_name + "';")
             content = content.replace("var DECISION_NAME = '';", "var DECISION_NAME = '" + conference.decision_name + "';")
+            content = content.replace("var LEGACY_INVITATION_ID = false;", "var LEGACY_INVITATION_ID = " + 'true' if conference.legacy_invitation_id else 'false' + ";")
             group.web = content
             return self.client.post_group(group)
 

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -60,7 +60,7 @@ class TestCommentNotification():
         conference.set_program_chairs(emails= ['programchair@midl.io'])
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True, unsubmitted_reviewers= True, reader_selection=True, email_pcs=True)
 
-        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
+        comment_invitation_id = '{conference_id}/Paper{number}/-/Official_Comment'.format(conference_id = conference.id, number = note.number)
         authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = note.number)
         reviewers_group_id = '{conference_id}/Paper{number}/Reviewers'.format(conference_id = conference.id, number = note.number)
         anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = note.number)
@@ -368,7 +368,7 @@ class TestCommentNotification():
 
         conference.open_reviews(release_to_authors=True)
 
-        note = openreview.Note(invitation = 'auai.org/UAI/2020/Conference/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'auai.org/UAI/2020/Conference/Paper1/-/Official_Review',
             forum = paper_note.id,
             replyto = paper_note.id,
             readers = ['auai.org/UAI/2020/Conference/Program_Chairs',
@@ -390,7 +390,7 @@ class TestCommentNotification():
 
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True, email_pcs=True)
 
-        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = paper_note.number)
+        comment_invitation_id = '{conference_id}/Paper{number}/-/Official_Comment'.format(conference_id = conference.id, number = paper_note.number)
         authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = paper_note.number)
         reviewers_group_id = '{conference_id}/Paper{number}/Reviewers/Submitted'.format(conference_id = conference.id, number = paper_note.number)
         anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = paper_note.number)
@@ -430,7 +430,7 @@ class TestCommentNotification():
         assert 'author@mail.com' in recipients
         assert 'test@mail.com' in recipients
 
-        note = openreview.Note(invitation = 'auai.org/UAI/2020/Conference/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'auai.org/UAI/2020/Conference/Paper1/-/Official_Review',
             forum = paper_note.id,
             replyto = paper_note.id,
             readers = ['auai.org/UAI/2020/Conference/Program_Chairs',
@@ -535,7 +535,7 @@ class TestCommentNotification():
         conference.set_program_chairs(emails = ['programchair@colt.io'])
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True, unsubmitted_reviewers = True, email_pcs = True)
 
-        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
+        comment_invitation_id = '{conference_id}/Paper{number}/-/Official_Comment'.format(conference_id = conference.id, number = note.number)
         authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = note.number)
         reviewers_group_id = '{conference_id}/Paper{number}/Reviewers'.format(conference_id = conference.id, number = note.number)
         anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = note.number)
@@ -821,7 +821,7 @@ class TestCommentNotification():
         conference.set_program_chairs(emails = ['programchair@colt17.io'])
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True, unsubmitted_reviewers = True)
 
-        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
+        comment_invitation_id = '{conference_id}/Paper{number}/-/Official_Comment'.format(conference_id = conference.id, number = note.number)
         authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = note.number)
         reviewers_group_id = '{conference_id}/Paper{number}/Reviewers'.format(conference_id = conference.id, number = note.number)
         anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = note.number)
@@ -1019,7 +1019,7 @@ class TestCommentNotification():
         assert notes
         note = notes[0]
 
-        comment_invitation_id = '{conference_id}/-/Paper{number}/Official_Comment'.format(conference_id = conference.id, number = note.number)
+        comment_invitation_id = '{conference_id}/Paper{number}/-/Official_Comment'.format(conference_id = conference.id, number = note.number)
         authors_group_id = '{conference_id}/Paper{number}/Authors'.format(conference_id = conference.id, number = note.number)
         reviewers_group_id = '{conference_id}/Paper{number}/Reviewers'.format(conference_id = conference.id, number = note.number)
         anon_reviewers_group_id = '{conference_id}/Paper{number}/AnonReviewer1'.format(conference_id = conference.id, number = note.number)

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -753,7 +753,7 @@ class TestDoubleBlindConference():
         conference.set_assignment('ac@mail.com', submission.number, is_area_chair = True)
         conference.set_assignment('reviewer2@mail.com', submission.number)
         now = datetime.datetime.utcnow()
-        conference.open_reviews('Official_Review', due_date = now + datetime.timedelta(minutes = 10), release_to_authors = True, release_to_reviewers = True)
+        conference.open_reviews(due_date = now + datetime.timedelta(minutes = 10), release_to_authors = True, release_to_reviewers = True)
 
         # Reviewer
         request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, reviewer_client.token)
@@ -908,7 +908,7 @@ class TestDoubleBlindConference():
         builder.set_conference_short_name('AKBC 2019')
         conference = builder.get_result()
 
-        conference.open_meta_reviews('Meta_Review', due_date = datetime.datetime(2019, 10, 5, 18, 00))
+        conference.open_meta_reviews(due_date = datetime.datetime(2019, 10, 5, 18, 00))
 
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -660,8 +660,9 @@ class TestDoubleBlindConference():
         builder.set_conference_id('AKBC.ws/2019/Conference')
         builder.set_double_blind(True)
         conference = builder.get_result()
+        conference.set_authors()
 
-        conference.open_comments('Public_Comment', public = True, anonymous = True)
+        conference.open_comments('Official_Comment', public = False, anonymous = True)
 
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]
@@ -669,7 +670,7 @@ class TestDoubleBlindConference():
 
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Public Comment' == reply_row.find_elements_by_class_name('btn')[0].text
+        assert 'Official Comment' == reply_row.find_elements_by_class_name('btn')[0].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -680,7 +681,7 @@ class TestDoubleBlindConference():
         builder.set_double_blind(True)
         conference = builder.get_result()
 
-        conference.close_comments('Public_Comment')
+        conference.close_comments('Official_Comment')
 
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Submission')
         submission = notes[0]
@@ -721,8 +722,8 @@ class TestDoubleBlindConference():
         conference.set_authors()
         conference.set_area_chairs(emails = ['ac@mail.com'])
         conference.set_reviewers(emails = ['reviewer2@mail.com'])
-
-        invitation = conference.open_bids(due_date = datetime.datetime(2019, 10, 5, 18, 00), request_count = 50, with_area_chairs = False)
+        now = datetime.datetime.utcnow()
+        invitation = conference.open_bids(due_date =  now + datetime.timedelta(minutes = 10), request_count = 50, with_area_chairs = False)
         assert invitation
 
         request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/-/Bid", reviewer_client.token)
@@ -751,7 +752,8 @@ class TestDoubleBlindConference():
 
         conference.set_assignment('ac@mail.com', submission.number, is_area_chair = True)
         conference.set_assignment('reviewer2@mail.com', submission.number)
-        conference.open_reviews('Official_Review', due_date = datetime.datetime(2019, 10, 5, 18, 00), release_to_authors = True, release_to_reviewers = True)
+        now = datetime.datetime.utcnow()
+        conference.open_reviews('Official_Review', due_date = now + datetime.timedelta(minutes = 10), release_to_authors = True, release_to_reviewers = True)
 
         # Reviewer
         request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, reviewer_client.token)
@@ -766,7 +768,7 @@ class TestDoubleBlindConference():
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 0
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Official_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['AKBC.ws/2019/Conference/Program_Chairs',
@@ -807,10 +809,10 @@ class TestDoubleBlindConference():
         assert 'reviewer2@mail.com' in recipients
 
         ## Check review visibility
-        notes = reviewer_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Paper1/Official_Review')
+        notes = reviewer_client.get_notes(invitation='AKBC.ws/2019/Conference/Paper1/-/Official_Review')
         assert len(notes) == 1
 
-        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Paper1/Official_Review')
+        notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/Paper1/-/Official_Review')
         assert len(notes) == 1
 
     def test_open_revise_reviews(self, client, test_client, selenium, request_page, helpers):
@@ -832,15 +834,14 @@ class TestDoubleBlindConference():
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]
 
-        reviews = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Paper.*/Official_Review')
+        reviews = test_client.get_notes(invitation='AKBC.ws/2019/Conference/Paper.*/-/Official_Review')
         assert reviews
         review = reviews[0]
 
         now = datetime.datetime.utcnow()
-        conference.open_revise_reviews(due_date = now + datetime.timedelta(minutes = 10))
-        conference.close_reviews()
+        conference.open_revise_reviews(due_date = now + datetime.timedelta(minutes = 100))
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Official_Review/AnonReviewer1/Revision',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Official_Review/AnonReviewer1/Revision',
             forum = submission.id,
             referent = review.id,
             readers = ['AKBC.ws/2019/Conference/Program_Chairs',
@@ -912,7 +913,7 @@ class TestDoubleBlindConference():
         notes = test_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Meta_Review',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Meta_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['AKBC.ws/2019/Conference/Paper1/Area_Chairs', 'AKBC.ws/2019/Conference/Program_Chairs'],
@@ -946,7 +947,7 @@ class TestDoubleBlindConference():
         notes = pc_client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Decision',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
             readers = ['AKBC.ws/2019/Conference/Program_Chairs'],
@@ -965,7 +966,7 @@ class TestDoubleBlindConference():
 
         conference.open_decisions(public=True)
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Decision',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
             readers = ['everyone'],
@@ -983,7 +984,7 @@ class TestDoubleBlindConference():
 
         conference.open_decisions(release_to_authors=True)
 
-        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/-/Paper1/Decision',
+        note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
             readers = ['AKBC.ws/2019/Conference/Program_Chairs',

--- a/tests/test_legacy_invitations.py
+++ b/tests/test_legacy_invitations.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import openreview
+import pytest
+import requests
+import datetime
+import time
+import os
+
+class TestLegacyInvitations():
+
+    def test_single_blind_conference(self, client, test_client, selenium, request_page, helpers) :
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('NIPS.cc/2019/Workshop/MLITS')
+        builder.set_conference_name('2019 NIPS MLITS Workshop')
+        builder.set_homepage_header({
+        'title': '2019 NIPS MLITS Workshop',
+        'subtitle': 'Machine Learning for Intelligent Transportation Systems',
+        'deadline': 'October 12, 2018, 11:59 pm UTC',
+        'date': 'December 3-8, 2018',
+        'website': 'https://sites.google.com/site/nips2018mlits/home',
+        'location': 'Montreal, Canada',
+        'instructions': ''
+        })
+        builder.has_area_chairs(True)
+        builder.use_legacy_invitation_id(True)
+        conference = builder.get_result()
+        now = datetime.datetime.utcnow()
+
+        invitation = conference.open_submissions(due_date = now + datetime.timedelta(minutes = 40))
+
+        note = openreview.Note(invitation = invitation.id,
+            readers = ['everyone'],
+            writers = ['~Test_User1', 'peter@mail.com', 'andrew@mail.com'],
+            signatures = ['~Test_User1'],
+            content = {
+                'title': 'Paper title',
+                'abstract': 'This is an abstract',
+                'authorids': ['test@mail.com', 'peter@mail.com', 'andrew@mail.com'],
+                'authors': ['Test User', 'Peter Test', 'Andrew Mc']
+            }
+        )
+        url = test_client.put_pdf(os.path.join(os.path.dirname(__file__), 'data/paper.pdf'))
+        note.content['pdf'] = url
+        test_client.post_note(note)
+
+        conference.set_authors()
+        conference.set_reviewers(['reviewer_legacy@mail.com'])
+        conference.set_area_chairs(['ac_legacy@mail.com'])
+        conference.set_program_chairs(['pc_legacy@mail.com'])
+        conference.set_assignment('reviewer_legacy@mail.com', 1)
+        conference.set_assignment('ac_legacy@mail.com', 1, True)
+
+        conference.open_comments('Official_Comment', public = False, anonymous = True)
+        conference.open_reviews(due_date = now + datetime.timedelta(minutes = 40))
+        conference.open_meta_reviews(due_date = now + datetime.timedelta(minutes = 40))
+        conference.open_decisions(due_date = now + datetime.timedelta(minutes = 40))
+
+        assert client.get_invitations(regex = 'NIPS.cc/2019/Workshop/MLITS/-/Paper.*/Official_Comment')
+        assert client.get_invitations(regex = 'NIPS.cc/2019/Workshop/MLITS/-/Paper.*/Official_Review')
+        assert client.get_invitations(regex = 'NIPS.cc/2019/Workshop/MLITS/-/Paper.*/Meta_Review')
+        assert client.get_invitations(regex = 'NIPS.cc/2019/Workshop/MLITS/-/Paper.*/Decision')
+
+        reviewer_client = helpers.create_user('reviewer_legacy@mail.com', 'Reviewer', 'Legacy')
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2019/Workshop/MLITS/Reviewers", reviewer_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('assigned-papers')
+        assert len(tabs.find_element_by_id('assigned-papers').find_elements_by_class_name('note')) == 1
+        assert tabs.find_element_by_id('reviewer-schedule')
+        assert len(tabs.find_element_by_id('reviewer-schedule').find_elements_by_tag_name('h4')) == 1
+        assert tabs.find_element_by_id('reviewer-tasks')
+        assert len(tabs.find_element_by_id('reviewer-tasks').find_elements_by_class_name('note')) == 1
+
+        ac_client = helpers.create_user('ac_legacy@mail.com', 'AC', 'Legacy')
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2019/Workshop/MLITS/Area_Chairs", ac_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('assigned-papers')
+        assert len(tabs.find_element_by_id('assigned-papers').find_elements_by_class_name('note')) == 1
+        assert tabs.find_element_by_id('areachair-schedule')
+        assert len(tabs.find_element_by_id('areachair-schedule').find_elements_by_tag_name('h4')) == 1
+        assert tabs.find_element_by_id('areachair-tasks')
+        assert len(tabs.find_element_by_id('areachair-tasks').find_elements_by_class_name('note')) == 1
+        reviews = tabs.find_elements_by_class_name('reviewer-progress')
+        assert reviews
+        assert len(reviews) == 1
+        headers = reviews[0].find_elements_by_tag_name('h4')
+        assert headers
+        assert headers[0].text == '0 of 1 Reviews Submitted'
+
+        pc_client = helpers.create_user('pc_legacy@mail.com', 'PC', 'Legacy')
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2019/Workshop/MLITS/Program_Chairs", pc_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('paper-status')
+        assert tabs.find_element_by_id('areachair-status')
+        assert tabs.find_element_by_id('reviewer-status')

--- a/tests/test_reviewers_conference.py
+++ b/tests/test_reviewers_conference.py
@@ -129,7 +129,7 @@ class TestReviewersConference():
         assert headers
         assert headers[0].text == '0 of 2 Reviews Submitted'
 
-        note = openreview.Note(invitation = 'eswc-conferences.org/ESWC/2019/Workshop/KGB/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'eswc-conferences.org/ESWC/2019/Workshop/KGB/Paper1/-/Official_Review',
             forum = note.id,
             replyto = note.id,
             readers = ['eswc-conferences.org/ESWC/2019/Workshop/KGB/Program_Chairs', 'eswc-conferences.org/ESWC/2019/Workshop/KGB/Paper1/Reviewers/Submitted'],

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -292,8 +292,9 @@ class TestSingleBlindConference():
 
         builder.set_conference_id('NIPS.cc/2018/Workshop/MLITS')
         conference = builder.get_result()
+        conference.set_authors()
 
-        conference.open_comments('Public_Comment', public = True, anonymous = True)
+        conference.open_comments('Official_Comment', public = False, anonymous = True)
 
         notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Submission')
         submission = notes[0]
@@ -301,7 +302,7 @@ class TestSingleBlindConference():
 
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 1
-        assert 'Public Comment' == reply_row.find_elements_by_class_name('btn')[0].text
+        assert 'Official Comment' == reply_row.find_elements_by_class_name('btn')[0].text
 
     def test_close_comments(self, client, test_client, selenium, request_page):
 
@@ -311,7 +312,7 @@ class TestSingleBlindConference():
         builder.set_conference_id('NIPS.cc/2018/Workshop/MLITS')
         conference = builder.get_result()
 
-        conference.close_comments('Public_Comment')
+        conference.close_comments('Official_Comment')
 
         notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Submission')
         submission = notes[0]
@@ -387,7 +388,7 @@ class TestSingleBlindConference():
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 0
 
-        note = openreview.Note(invitation = 'NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['NIPS.cc/2018/Workshop/MLITS/Program_Chairs', 'NIPS.cc/2018/Workshop/MLITS/Paper1/Area_Chairs', 'NIPS.cc/2018/Workshop/MLITS/Paper1/Reviewers/Submitted'],
@@ -422,17 +423,17 @@ class TestSingleBlindConference():
         assert 'reviewer@mail.com' in recipients
 
         ## Check review visibility
-        notes = reviewer_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review')
+        notes = reviewer_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 1
 
-        notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review')
+        notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 0
 
         reviewer2_client = helpers.create_user('reviewer3@mail.com', 'Reviewer', 'Three')
-        notes = reviewer2_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review')
+        notes = reviewer2_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 0
 
-        note = openreview.Note(invitation = 'NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['NIPS.cc/2018/Workshop/MLITS/Program_Chairs', 'NIPS.cc/2018/Workshop/MLITS/Paper1/Area_Chairs', 'NIPS.cc/2018/Workshop/MLITS/Paper1/Reviewers/Submitted'],
@@ -449,10 +450,10 @@ class TestSingleBlindConference():
         review_note = reviewer2_client.post_note(note)
         assert review_note
 
-        notes = reviewer2_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review')
+        notes = reviewer2_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 2
 
-        notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/-/Paper1/Official_Review')
+        notes = test_client.get_notes(invitation='NIPS.cc/2018/Workshop/MLITS/Paper1/-/Official_Review')
         assert len(notes) == 0
 
         messages = client.get_messages(subject = '[MLITS 2018] Review posted to your assigned paper: "New paper title"')

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -361,7 +361,7 @@ class TestSingleBlindConference():
         conference.set_assignment('ac2@mail.com', submission.number, is_area_chair = True)
         conference.set_assignment('reviewer@mail.com', submission.number)
         conference.set_assignment('reviewer3@mail.com', submission.number)
-        conference.open_reviews('Official_Review', due_date = datetime.datetime(2019, 10, 5, 18, 00), additional_fields = {
+        conference.open_reviews(due_date = datetime.datetime(2019, 10, 5, 18, 00), additional_fields = {
             'rating': {
                 'order': 3,
                 'value-dropdown': [

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -355,10 +355,10 @@ class TestSingleBlindConference():
         conference = builder.get_result()
         conference.set_authors()
         conference.set_program_chairs(emails = ['pc2@mail.com'])
-        conference.set_area_chairs(emails = ['ac@mail.com'])
+        conference.set_area_chairs(emails = ['ac2@mail.com'])
         conference.set_reviewers(emails = ['reviewer@mail.com', 'reviewer3@mail.com'])
 
-        conference.set_assignment('ac@mail.com', submission.number, is_area_chair = True)
+        conference.set_assignment('ac2@mail.com', submission.number, is_area_chair = True)
         conference.set_assignment('reviewer@mail.com', submission.number)
         conference.set_assignment('reviewer3@mail.com', submission.number)
         conference.open_reviews('Official_Review', due_date = datetime.datetime(2019, 10, 5, 18, 00), additional_fields = {
@@ -415,7 +415,7 @@ class TestSingleBlindConference():
         messages = client.get_messages(subject = '[MLITS 2018] Review posted to your assigned paper: "New paper title"')
         assert len(messages) == 1
         recipients = [m['content']['to'] for m in messages]
-        assert 'ac@mail.com' in recipients
+        assert 'ac2@mail.com' in recipients
 
         messages = client.get_messages(subject = '[MLITS 2018] Your review has been received on your assigned paper: "New paper title"')
         assert len(messages) == 1
@@ -459,7 +459,7 @@ class TestSingleBlindConference():
         messages = client.get_messages(subject = '[MLITS 2018] Review posted to your assigned paper: "New paper title"')
         assert len(messages) == 2
         recipients = [m['content']['to'] for m in messages]
-        assert 'ac@mail.com' in recipients
+        assert 'ac2@mail.com' in recipients
 
     def test_consoles(self, client, test_client, selenium, request_page, helpers):
 
@@ -565,7 +565,7 @@ class TestSingleBlindConference():
         assert len(tabs.find_element_by_id('reviewer-tasks').find_elements_by_class_name('note')) == 1
 
         # Area chair user
-        ac_client = helpers.create_user('ac@mail.com', 'AC', 'MLITS')
+        ac_client = helpers.create_user('ac2@mail.com', 'AC', 'MLITS')
         request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS", ac_client.token)
         notes_panel = selenium.find_element_by_id('notes')
         assert notes_panel
@@ -593,25 +593,7 @@ class TestSingleBlindConference():
         assert headers[0].text == '2 of 2 Reviews Submitted'
 
         #Program chair user
-        pc_client = openreview.Client(baseurl = 'http://localhost:3000')
-        assert pc_client is not None, "Client is none"
-        res = pc_client.register_user(email = 'pc2@mail.com', first = 'ProgramChair', last = 'Test', password = '1234')
-        assert res, "Res i none"
-        res = pc_client.activate_user('pc2@mail.com', {
-            'names': [
-                    {
-                        'first': 'ProgramChair',
-                        'last': 'Test',
-                        'username': '~ProgramChair_Test1'
-                    }
-                ],
-            'emails': ['pc2@mail.com'],
-            'preferredEmail': 'pc2@mail.com'
-            })
-        assert res, "Res i none"
-        group = pc_client.get_group(id = 'pc2@mail.com')
-        assert group
-        assert group.members == ['~ProgramChair_Test1']
+        pc_client = helpers.create_user('pc2@mail.com', 'ProgramChair', 'Test')
 
         request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS", pc_client.token)
         notes_panel = selenium.find_element_by_id('notes')
@@ -623,5 +605,11 @@ class TestSingleBlindConference():
         console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
         assert 'Program Chair Console' == console.find_element_by_tag_name('a').text
 
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS/Program_Chairs", pc_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('paper-status')
+        assert tabs.find_element_by_id('areachair-status')
+        assert tabs.find_element_by_id('reviewer-status')
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,7 +10,7 @@ class TestTools():
 
     def test_get_submission_invitations(self, client):
         invitations = openreview.tools.get_submission_invitations(client)
-        assert len(invitations) == 6, "Invitations could not be retrieved"
+        assert len(invitations) == 7, "Invitations could not be retrieved"
 
     def test_get_all_venues(self, client):
         venues = openreview.tools.get_all_venues(client)

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -269,13 +269,14 @@ class TestWorkshop():
         notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]
 
-        conference.set_assignment('reviewer4@mail.com', submission.number)
-        conference.open_reviews('Official_Review', due_date = datetime.datetime(2019, 10, 5, 18, 00), release_to_authors= True, release_to_reviewers=True)
-
         # Reviewer
         reviewer_client = helpers.create_user('reviewer4@mail.com', 'Reviewer', 'Four')
-        request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, reviewer_client.token)
 
+        conference.set_assignment('reviewer4@mail.com', submission.number)
+        now = datetime.datetime.utcnow()
+        conference.open_reviews('Official_Review', due_date = now + datetime.timedelta(minutes = 10), release_to_authors= True, release_to_reviewers=True)
+
+        request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, reviewer_client.token)
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 1
         assert 'Official Review' == reply_row.find_elements_by_class_name('btn')[0].text

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -274,7 +274,7 @@ class TestWorkshop():
 
         conference.set_assignment('reviewer4@mail.com', submission.number)
         now = datetime.datetime.utcnow()
-        conference.open_reviews('Official_Review', due_date = now + datetime.timedelta(minutes = 10), release_to_authors= True, release_to_reviewers=True)
+        conference.open_reviews(due_date = now + datetime.timedelta(minutes = 10), release_to_authors= True, release_to_reviewers=True)
 
         request_page(selenium, "http://localhost:3000/forum?id=" + submission.id, reviewer_client.token)
         reply_row = selenium.find_element_by_class_name('reply_row')
@@ -503,7 +503,7 @@ class TestWorkshop():
         builder.set_submission_public(False)
         builder.has_area_chairs(False)
         conference = builder.get_result()
-        conference.open_meta_reviews('Meta_Review')
+        conference.open_meta_reviews()
 
         notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -286,7 +286,7 @@ class TestWorkshop():
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 0
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs',
@@ -315,10 +315,10 @@ class TestWorkshop():
         assert len(messages) == 0
 
         ## Check review visibility
-        notes = reviewer_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review')
+        notes = reviewer_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
         assert len(notes) == 1
 
-        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review')
+        notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
         assert len(notes) == 1
 
     def test_open_comments(self, client, test_client, selenium, request_page, helpers):
@@ -346,13 +346,13 @@ class TestWorkshop():
         notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]
 
-        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review')
+        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
         assert reviews
         review = reviews[0]
 
         conference.open_comments(name = 'Official_Comment', public = False, anonymous = True, unsubmitted_reviewers = True, email_pcs = True)
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Comment',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Comment',
             forum = submission.id,
             replyto = review.id,
             readers = [
@@ -394,7 +394,7 @@ class TestWorkshop():
 
         conference.open_comments(name = 'Public_Comment', public = True, anonymous = False)
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Public_Comment',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Public_Comment',
             forum = submission.id,
             replyto = review.id,
             readers = ['everyone'],
@@ -439,15 +439,14 @@ class TestWorkshop():
         notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]
 
-        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review')
+        reviews = client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review')
         assert reviews
         review = reviews[0]
 
         now = datetime.datetime.utcnow()
         conference.open_revise_reviews(due_date = now + datetime.timedelta(minutes = 10))
-        conference.close_reviews()
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Official_Review/AnonReviewer1/Revision',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Official_Review/AnonReviewer1/Revision',
             forum = submission.id,
             referent = review.id,
             readers = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs',
@@ -508,7 +507,7 @@ class TestWorkshop():
         notes = test_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Meta_Review',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Meta_Review',
             forum = submission.id,
             replyto = submission.id,
             readers = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs'],
@@ -553,7 +552,7 @@ class TestWorkshop():
         notes = pc_client.get_notes(invitation='icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Blind_Submission')
         submission = notes[0]
 
-        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/-/Paper1/Decision',
+        note = openreview.Note(invitation = 'icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
             readers = ['icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs'],


### PR DESCRIPTION
- Build paper invitation id using the paper group as prefix, for example:

```
Test.cc/2019/Conference/Paper1/-/Official_Review
```

To don't break current **active venues**, you need to set:

```
builder.use_legacy_invitation_id(True)
```

and that will create the invitations using Paper1 as part of the invitation name. 

- All the webfileds support both versions of invitation ids. 

- Tests have been modified to use the new invitation format. One test was added to test legacy ids.

I believe that I need to fix openreview Tasks view to group all the tasks below the same venue. I will do it tomorrow morning.

It depends on https://github.com/iesl/openreview/pull/1424