### PR TITLE
Fix/consoles

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -507,13 +507,17 @@ class Conference(object):
 
     def set_authors(self):
         notes_iterator = self.get_submissions(details='original')
+        author_group_ids = []
 
         for n in notes_iterator:
             group = self.__create_group('{conference_id}/Paper{number}'.format(conference_id = self.id, number = n.number), self.id)
             authorids = n.content.get('authorids')
             if n.details and n.details.get('original'):
                 authorids = n.details['original']['content']['authorids']
-            self.__create_group('{number_group}/{author_name}'.format(number_group = group.id, author_name = self.authors_name), self.id, authorids)
+            group = self.__create_group('{number_group}/{author_name}'.format(number_group = group.id, author_name = self.authors_name), self.id, authorids)
+            author_group_ids.append(group.id)
+
+        self.__create_group(self.get_authors_id(), self.id, author_group_ids)
 
     def setup_matching(self, affinity_score_file = None, tpms_score_file = None):
         conference_matching = matching.Matching(self)

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -40,7 +40,7 @@ function load() {
   var invitationsP;
   var tagInvitationsP;
 
-  if (!user) {
+  if (!user || _.startsWith(user.id, 'guest_')) {
     authorNotesP = $.Deferred().resolve([]);
     invitationsP = $.Deferred().resolve([]);
     tagInvitationsP = $.Deferred().resolve([]);
@@ -83,11 +83,6 @@ function load() {
 function renderConferenceTabs() {
   var sections = [
     {
-      heading: 'Your Submissions',
-      id: 'your-submissions',
-      active: true
-    },
-    {
       heading: 'Author Schedule',
       id: 'author-schedule',
       content: HEADER.schedule
@@ -95,6 +90,11 @@ function renderConferenceTabs() {
     {
       heading: 'Author Tasks',
       id: 'author-tasks'
+    },
+    {
+      heading: 'Your Submissions',
+      id: 'your-submissions',
+      active: true
     }
   ];
 
@@ -114,21 +114,14 @@ function renderContent(authorNotes, invitations, tagInvitations) {
   $(tasksOptions.container).empty();
 
   Webfield.ui.newTaskList(invitations, tagInvitations, tasksOptions);
-  $('.tabs-container a[href="#author-tasks"]').parent().show();
 
   // Your Private Versions and Your Anonymous Versions tabs
-  if (authorNotes.length) {
-    Webfield.ui.submissionList(authorNotes, {
-      heading: null,
-      container: '#your-submissions',
-      search: { enabled: false },
-      displayOptions: paperDisplayOptions
-    });
-
-    $('.tabs-container a[href="#your-submissions"]').parent().show();
-  } else {
-    $('.tabs-container a[href="#your-submissions"]').parent().hide();
-  }
+  Webfield.ui.submissionList(authorNotes, {
+    heading: null,
+    container: '#your-submissions',
+    search: { enabled: false },
+    displayOptions: paperDisplayOptions
+  });
 
   // Remove spinner and show content
   $('#notes .spinner-container').remove();

--- a/openreview/conference/templates/authorWebfield.js
+++ b/openreview/conference/templates/authorWebfield.js
@@ -83,6 +83,11 @@ function load() {
 function renderConferenceTabs() {
   var sections = [
     {
+      heading: 'Your Submissions',
+      id: 'your-submissions',
+      active: true
+    },
+    {
       heading: 'Author Schedule',
       id: 'author-schedule',
       content: HEADER.schedule
@@ -90,10 +95,6 @@ function renderConferenceTabs() {
     {
       heading: 'Author Tasks',
       id: 'author-tasks'
-    },
-    {
-      heading: 'Your Submissions',
-      id: 'your-submissions',
     }
   ];
 

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -338,11 +338,26 @@ var displayPaperStatusTable = function(profiles, notes, completedReviews, metaRe
       var reviewHtml = Handlebars.templates.noteReviewers(d.reviewProgressData);
       var areachairHtml = Handlebars.templates.noteAreaChairs(d.areachairProgressData);
       var decisionHtml = '<h4>' + (d.decision ? d.decision.content.decision : 'No Decision') + '</h4>';
-      return [number, summaryHtml, reviewHtml, areachairHtml, decisionHtml];
+      var rows = [];
+      rows.push(number);
+      rows.push(summaryHtml);
+      rows.push(reviewHtml);
+      if (SHOW_AC_TAB) {
+        rows.push(areachairHtml);
+      }
+      rows.push(decisionHtml);
+      return rows;
     });
 
+    var headings = ['#', 'Paper Summary', 'Review Progress'];
+    if (SHOW_AC_TAB) {
+      headings.push('Status');
+    }
+    headings.push('Decision');
+
+
     var tableHTML = Handlebars.templates['components/table']({
-      headings: ['#', 'Paper Summary', 'Review Progress', 'Status', 'Decision'],
+      headings: headings,
       rows: rowData,
       extraClasses: 'console-table paper-table'
     });
@@ -351,9 +366,14 @@ var displayPaperStatusTable = function(profiles, notes, completedReviews, metaRe
     $(container).append(tableHTML);
     $('.console-table th').eq(0).css('width', '4%');
     $('.console-table th').eq(1).css('width', '26%');
-    $('.console-table th').eq(2).css('width', '30%');
-    $('.console-table th').eq(3).css('width', '25%');
-    $('.console-table th').eq(4).css('width', '15%');
+    if (SHOW_AC_TAB) {
+      $('.console-table th').eq(2).css('width', '30%');
+      $('.console-table th').eq(3).css('width', '25%');
+      $('.console-table th').eq(4).css('width', '15%');
+    } else {
+      $('.console-table th').eq(2).css('width', '45%');
+      $('.console-table th').eq(3).css('width', '25%');
+    }
   }
 
   if (rowData.length) {

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -1073,3 +1073,19 @@ class TestDoubleBlindConference():
         assert len(tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')) == 1
         console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
         assert 'Program Chair Console' == console.find_element_by_tag_name('a').text
+
+        request_page(selenium, "http://localhost:3000/group?id=AKBC.ws/2019/Conference/Program_Chairs", pc_client.token)
+        assert "AKBC 2019 Conference Program Chairs | OpenReview" in selenium.title
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('paper-status')
+        assert tabs.find_element_by_id('reviewer-status')
+        assert tabs.find_element_by_id('areachair-status')
+
+        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-0').text
+        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
+        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
+        assert 'Status' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
+        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4').text

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -986,6 +986,7 @@ class TestDoubleBlindConference():
         builder.set_conference_id('AKBC.ws/2019/Conference')
         builder.set_double_blind(True)
         builder.set_conference_short_name('AKBC 2019')
+        builder.has_area_chairs(True)
         conference = builder.get_result()
 
         conference.set_program_chairs(emails = ['akbc_pc@mail.com'])
@@ -999,7 +1000,7 @@ class TestDoubleBlindConference():
         note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
-            readers = ['AKBC.ws/2019/Conference/Program_Chairs'],
+            readers = ['AKBC.ws/2019/Conference/Program_Chairs', 'AKBC.ws/2019/Conference/Paper1/Area_Chairs'],
             nonreaders = ['AKBC.ws/2019/Conference/Paper' + str(submission.number) + '/Authors'],
             writers = ['AKBC.ws/2019/Conference/Program_Chairs'],
             signatures = ['AKBC.ws/2019/Conference/Program_Chairs'],
@@ -1036,7 +1037,7 @@ class TestDoubleBlindConference():
         note = openreview.Note(invitation = 'AKBC.ws/2019/Conference/Paper1/-/Decision',
             forum = submission.id,
             replyto = submission.id,
-            readers = ['AKBC.ws/2019/Conference/Program_Chairs',
+            readers = ['AKBC.ws/2019/Conference/Program_Chairs', 'AKBC.ws/2019/Conference/Paper1/Area_Chairs',
             'AKBC.ws/2019/Conference/Paper' + str(submission.number) + '/Authors'],
             writers = ['AKBC.ws/2019/Conference/Program_Chairs'],
             signatures = ['AKBC.ws/2019/Conference/Program_Chairs'],
@@ -1058,6 +1059,7 @@ class TestDoubleBlindConference():
         builder.set_conference_id('AKBC.ws/2019/Conference')
         builder.set_double_blind(True)
         builder.set_conference_short_name('AKBC 2019')
+        builder.has_area_chairs(True)
         conference = builder.get_result()
 
         #Program chair user

--- a/tests/test_single_blind_conference.py
+++ b/tests/test_single_blind_conference.py
@@ -483,7 +483,7 @@ class TestSingleBlindConference():
         console = tabs.find_element_by_id('your-consoles').find_elements_by_tag_name('ul')[0]
         assert 'Author Console' == console.find_element_by_tag_name('a').text
 
-        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token)
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS/Authors#author-schedule", test_client.token)
         tabs = selenium.find_element_by_class_name('tabs-container')
         assert tabs
         assert tabs.find_element_by_id('author-schedule')
@@ -501,7 +501,7 @@ class TestSingleBlindConference():
             'schedule': 'This is a schedule'
         })
 
-        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS/Authors", test_client.token)
+        request_page(selenium, "http://localhost:3000/group?id=NIPS.cc/2018/Workshop/MLITS/Authors#author-schedule", test_client.token)
 
         header = selenium.find_element_by_id('header')
         assert header

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -609,3 +609,26 @@ class TestWorkshop():
         assert notes_panel
         tabs = notes_panel.find_element_by_class_name('tabs-container')
         assert tabs
+
+    def test_pc_console(self, client, selenium, request_page):
+
+        pc_client = openreview.Client(username = 'program_chairs@hsdip.org', password = '1234')
+
+        request_page(selenium, "http://localhost:3000/group?id=icaps-conference.org/ICAPS/2019/Workshop/HSDIP/Program_Chairs", pc_client.token)
+        assert "ICAPS 2019 Workshop HSDIP Program Chairs | OpenReview" in selenium.title
+        notes_panel = selenium.find_element_by_id('notes')
+        assert notes_panel
+        tabs = notes_panel.find_element_by_class_name('tabs-container')
+        assert tabs
+        assert tabs.find_element_by_id('paper-status')
+        assert tabs.find_element_by_id('reviewer-status')
+        with pytest.raises(NoSuchElementException):
+            assert tabs.find_element_by_id('areachair-status')
+
+        assert '#' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-0').text
+        assert 'Paper Summary' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-1').text
+        assert 'Review Progress' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-2').text
+        assert 'Decision' == tabs.find_element_by_id('paper-status').find_element_by_class_name('row-3').text
+
+        with pytest.raises(NoSuchElementException):
+            assert tabs.find_element_by_id('paper-status').find_element_by_class_name('row-4')


### PR DESCRIPTION
Console improvements:

- Show the submissions tab 'always' in the Author console.
- Set the submissions tab 'active' in the Author console.
- Create the conference author group and add all the paper author groups as members. It will be used to notify authors. 
- Show the meta-review column 'only' where there are area chairs in the PC Console.
- Fix tests.