### PR TITLE
Fix/setup matching

### DIFF
--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -696,12 +696,11 @@ class InvitationBuilder(object):
             duedate = tools.datetime_millis(due_date),
             expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
             readers = [conference.get_program_chairs_id(), conference.get_area_chairs_id()],
-            invitees = [],
             writers = [conference.get_id()],
             signatures = [conference.get_id()],
+            invitees = [conference.get_program_chairs_id(), conference.get_area_chairs_id()],
             multiReply = True,
             reply = {
-                'invitation': conference.get_blind_submission_id(),
                 'readers': {
                     'description': 'The users who will be allowed to read the above content.',
                     'values-copied': [conference.get_id(), '{signatures}']
@@ -711,59 +710,28 @@ class InvitationBuilder(object):
                     'values-regex': '~.*'
                 },
                 'content': {
-                    'tag': {
-                        'description': 'Recommend reviewer',
-                        'order': 1,
-                        'required': True,
-                        'values-url': '/groups?id=' + conference.get_reviewers_id()
+                    'head': {
+                        'type': 'Note',
+                        'query': {
+                            'invitation': conference.get_blind_submission_id()
+                        }
+                    },
+                    'tail': {
+                        'type': 'Group',
+                        'query': {
+                            'id': conference.get_reviewers_id()
+                        }
+                    },
+                    'weight': {
+                        'value-regex': '[0-9]+',
+                        'required': True
                     }
                 }
             }
         )
 
         recommendation_invitation = self.client.post_invitation(recommendation_invitation)
-        # Create subinvitation with different list of reviewers, bid, tpms score.
 
-        for note in notes_iterator:
-            reviewers = []
-            assignment_note = assignment_note_by_forum.get(note.id)
-            reply = {
-                'forum': note.id
-            }
-            if assignment_note:
-                for group in assignment_note['assignedGroups']:
-                    reviewers.append('{profileId} (A) - Bid: {bid} - Tpms: {tpms}'.format(
-                        profileId = group.get('userId'),
-                        bid = group.get('scores').get('bid'),
-                        tpms = group.get('scores').get('affinity'))
-                    )
-                for group in assignment_note['alternateGroups']:
-                    reviewers.append('{profileId} - Bid: {bid} - Tpms: {tpms}'.format(
-                        profileId = group.get('userId'),
-                        bid = group.get('scores').get('bid'),
-                        tpms = group.get('scores').get('affinity'))
-                    )
-                reply['content'] = {
-                    'tag': {
-                        'description': 'Recommend reviewer',
-                        'order': 1,
-                        'required': True,
-                        'values-dropdown': reviewers
-                    }
-                }
-            paper_recommendation_invitation = openreview.Invitation(
-                id = conference.get_recommendation_id(number = note.number),
-                cdate = tools.datetime_millis(start_date),
-                duedate = tools.datetime_millis(due_date),
-                expdate = tools.datetime_millis(due_date + datetime.timedelta(minutes = SHORT_BUFFER_MIN)),
-                super = recommendation_invitation.id,
-                invitees = [conference.get_program_chairs_id(), conference.get_area_chairs_id(note.number)],
-                writers = [conference.get_id()],
-                signatures = [conference.get_id()],
-                multiReply = True,
-                reply = reply
-            )
-            paper_recommendation_invitation = self.client.post_invitation(paper_recommendation_invitation)
 
 
     def set_registration_invitation(self, conference, start_date, due_date, with_area_chairs):

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -171,27 +171,25 @@ class BidInvitation(openreview.Invitation):
             multiReply = True,
             taskCompletionCount = bid_stage.request_count,
             reply = {
-                'forum': None,
-                'replyto': None,
-                'invitation': conference.get_blind_submission_id(),
                 'readers': {
                     'values-copied': [conference.get_id(), '{signatures}']
                 },
                 'signatures': {
                     'values-regex': '~.*'
                 },
+                'signatures': {
+                    'values-regex': '~.*'
+                },
                 'content': {
-                    'edge': {
-                        'required': True,
-                        'head': 'profile',
-                        'tail': 'note',
-                        'value-radio': [
-                            ['Very High', 1],
-                            ['High', 0.5],
-                            ['Neutral', 0],
-                            ['Low', -0.5],
-                            ['Very Low', -1]
-                        ]
+                    'head': {
+                        'type': 'Note'
+                    },
+                    'tail': {
+                        'type': 'Group'
+                    },
+                    'label': {
+                        'value-radio': ['Very High', 'High', 'Neutral', 'Low', 'Very Low'],
+                        'required': True
                     }
                 }
             }

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -9,9 +9,7 @@ class Matching(object):
         self.conference = conference
 
     def clear(self, client, invitation):
-        note_list = list(openreview.tools.iterget_notes(client, invitation = invitation))
-        for note in note_list:
-            client.delete_note(note)
+        return client.delete_edges(invitation)
 
     def _build_conflicts(self, client, papers, user_profiles):
         edges = []
@@ -465,6 +463,12 @@ class Matching(object):
         self.conference.client.post_invitation(aggregated_score_inv)
         self.conference.client.post_invitation(custom_load_inv)
         self.conference.client.post_invitation(conflicts_inv)
+
+        self.clear(self.conference.client, self.conference.get_paper_assignment_id())
+        self.clear(self.conference.client, self.conference.get_invitation_id('Conflicts'))
+        self.clear(self.conference.client, self.conference.get_invitation_id('Custom_Load'))
+        self.clear(self.conference.client, self.conference.get_invitation_id('Aggregate_Score'))
+
 
         submissions = list(openreview.tools.iterget_notes(
             self.conference.client, invitation = self.conference.get_blind_submission_id(), details='original'))

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -626,6 +626,7 @@ class Client(object):
         '''
         send_json = [edge.to_json() for edge in edges]
         response = requests.post(self.bulk_edges_url, json = send_json, headers = self.headers)
+        response = self.__handle_response(response)
         received_json_array = response.json()
         edge_objects = [Edge.from_json(edge) for edge in received_json_array]
         return edge_objects

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -631,17 +631,6 @@ class Client(object):
         edge_objects = [Edge.from_json(edge) for edge in received_json_array]
         return edge_objects
 
-    def post_bulk_edges (self, edges):
-        offset=50000 # post_edges works for 50,000 edges but not for 100,000
-        num_edges = len(edges)
-        result = []
-        for i in range(0, num_edges, offset):
-            end = i + offset if i+offset < num_edges else num_edges
-            batch = self.post_edges(edges[i:end])
-            result += batch
-        return result
-
-
     def delete_note(self, note):
         """
         Deletes the note and returns a {status = 'ok'} in case of a successful deletion and an OpenReview exception otherwise.

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -631,6 +631,14 @@ class Client(object):
         edge_objects = [Edge.from_json(edge) for edge in received_json_array]
         return edge_objects
 
+    def delete_edges(self, invitation):
+        """
+        Deletes edges by invitation.
+        """
+        response = requests.delete(self.edges_url, json = { 'invitation': invitation }, headers = self.headers)
+        response = self.__handle_response(response)
+        return response.json()
+
     def delete_note(self, note):
         """
         Deletes the note and returns a {status = 'ok'} in case of a successful deletion and an OpenReview exception otherwise.

--- a/openreview/tools.py
+++ b/openreview/tools.py
@@ -1182,3 +1182,12 @@ def get_profile_info(profile):
         'emails': emails,
         'relations': relations
     }
+
+def post_bulk_edges (client, edges, batch_size = 50000):
+    num_edges = len(edges)
+    result = []
+    for i in range(0, num_edges, batch_size):
+        end = min(i + batch_size, num_edges)
+        batch = client.post_edges(edges[i:end])
+        result += batch
+    return result

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -13,13 +13,17 @@ class TestEdges:
         # Edge invitation
         inv1 = openreview.Invitation(id=conference.id + '/-/affinity', reply={
             'content': {
-                'edge': {
-                    'head': 'note',
-                    'tail': 'profile',
-                    'value-radio': [
-                        ['Very High', 1], ['High', 0.5], ['Neutral', 0],
-                        ['Low', -0.5], ['Very Low', -1]
-                    ]
+                'head': {
+                    'type': 'Note'
+                },
+                'tail': {
+                    'type': 'Profile',
+                },
+                'label': {
+                    'value-radio': ['Very High', 'High', 'Neutral', 'Low', 'Very Low']
+                },
+                'weight': {
+                    'value-regex': r'[0-9]+\.[0-9]'
                 }
             }
         })
@@ -51,6 +55,6 @@ class TestEdges:
                 signatures=['~Super_User1'])
             edges.append(edge)
 
-        client.post_bulk_edges(edges)
+        openreview.tools.post_bulk_edges(client, edges)
         them = list(openreview.tools.iterget_edges(client, invitation=inv1.id))
         assert len(edges) == len(them)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -294,17 +294,21 @@ class TestMatching():
         tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
         assert tpms_scores
         assert 15 == len(tpms_scores)
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[0].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
-        assert tpms_scores[0].tail == 'r3@fb.com'
-        assert tpms_scores[0].head == submissions[0].id
-        assert tpms_scores[1].weight == 0.31
-        assert tpms_scores[1].tail == 'r3@fb.com'
-        assert tpms_scores[1].head == submissions[1].id
-        assert tpms_scores[2].weight == 0.51
-        assert tpms_scores[2].tail == 'r3@fb.com'
-        assert tpms_scores[2].head == submissions[2].id
-        assert tpms_scores[3].weight == 0.77
-        assert tpms_scores[3].tail == 'r2@google.com'
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[1].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.31
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[2].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.51
 
 
     def test_setup_matching_with_recommendations(self, client, test_client, helpers):
@@ -418,17 +422,21 @@ class TestMatching():
         tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
         assert tpms_scores
         assert 15 == len(tpms_scores)
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[0].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
-        assert tpms_scores[0].tail == 'r3@fb.com'
-        assert tpms_scores[0].head == submissions[0].id
-        assert tpms_scores[1].weight == 0.31
-        assert tpms_scores[1].tail == 'r3@fb.com'
-        assert tpms_scores[1].head == submissions[1].id
-        assert tpms_scores[2].weight == 0.51
-        assert tpms_scores[2].tail == 'r3@fb.com'
-        assert tpms_scores[2].head == submissions[2].id
-        assert tpms_scores[3].weight == 0.77
-        assert tpms_scores[3].tail == 'r2@google.com'
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[1].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.31
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[2].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.51
 
 
     def test_setup_matching_with_subject_areas(self, client, test_client, helpers):
@@ -531,24 +539,37 @@ class TestMatching():
         tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
         assert tpms_scores
         assert 15 == len(tpms_scores)
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[0].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
-        assert tpms_scores[0].tail == 'r3@fb.com'
-        assert tpms_scores[0].head == submissions[0].id
-        assert tpms_scores[1].weight == 0.31
-        assert tpms_scores[1].tail == 'r3@fb.com'
-        assert tpms_scores[1].head == submissions[1].id
-        assert tpms_scores[2].weight == 0.51
-        assert tpms_scores[2].tail == 'r3@fb.com'
-        assert tpms_scores[2].head == submissions[2].id
-        assert tpms_scores[3].weight == 0.77
-        assert tpms_scores[3].tail == 'r2@google.com'
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[1].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.31
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS', tail = 'r3@fb.com', head = submissions[2].id)
+        assert tpms_scores
+        assert 1 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.51
 
         subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Subject_Areas')
         assert subject_areas_scores
         assert 3 == len(subject_areas_scores)
-        assert subject_areas_scores[0].tail == '~AreaChair_One1'
-        assert subject_areas_scores[0].weight == 0.3333333333333333
-        assert subject_areas_scores[1].tail == '~AreaChair_One1'
-        assert subject_areas_scores[1].weight == 1
-        assert subject_areas_scores[2].tail == '~AreaChair_One1'
-        assert subject_areas_scores[2].weight == 0.3333333333333333
+
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Subject_Areas', tail = '~AreaChair_One1', head = submissions[0].id)
+        assert subject_areas_scores
+        assert 1 == len(subject_areas_scores)
+        assert subject_areas_scores[0].weight ==  0.3333333333333333
+
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Subject_Areas', tail = '~AreaChair_One1', head = submissions[1].id)
+        assert subject_areas_scores
+        assert 1 == len(subject_areas_scores)
+        assert subject_areas_scores[0].weight ==  1
+
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Subject_Areas', tail = '~AreaChair_One1', head = submissions[2].id)
+        assert subject_areas_scores
+        assert 1 == len(subject_areas_scores)
+        assert subject_areas_scores[0].weight ==  0.3333333333333333

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -336,86 +336,73 @@ class TestMatching():
 
         ## Recommend reviewers
         ac1_client = helpers.get_user('ac1@cmu.edu')
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_recommendation_id(blinded_notes[0].number),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_recommendation_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[0].id,
-            tag = '~Reviewer_One1'
+            writers = ['~AreaChair_One1'],
+            head = blinded_notes[0].id,
+            tail = '~Reviewer_One1',
+            weight = 1
         ))
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_recommendation_id(blinded_notes[1].number),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_recommendation_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[1].id,
-            tag = 'r2@google.com'
+            writers = ['~AreaChair_One1'],
+            head = blinded_notes[1].id,
+            tail = 'r2@google.com',
+            weight = 2
         ))
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_recommendation_id(blinded_notes[1].number),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_recommendation_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[1].id,
-            tag = 'r3@fb.com'
+            writers = ['~AreaChair_One1'],
+            head = blinded_notes[1].id,
+            tail = 'r3@fb.com',
+            weight = 3
         ))
 
         ## Set up matching
-        metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        # assert metadata_notes
-        # assert len(metadata_notes) == 3
+        conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
 
-        # ## Assert Paper 1 scores
-        # assert metadata_notes[0].forum == blinded_notes[0].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
-        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
-        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        bids = client.get_edges(invitation = conference.get_bid_id())
+        assert bids
+        assert 6 == len(bids)
 
-        # ## Assert Paper 2 scores
-        # assert metadata_notes[1].forum == blinded_notes[1].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
-        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
-        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
-        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        recommendations = client.get_edges(invitation = conference.get_recommendation_id())
+        assert recommendations
+        assert 3 == len(recommendations)
 
-        # ## Assert Paper 3 scores
-        # assert metadata_notes[2].forum == blinded_notes[2].id
-        # assert len(metadata_notes[2].content['entries']) == 5
-        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
-        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert not custom_loads
+
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert conflicts
+        assert 3 == len(conflicts)
+        assert conflicts[0].label == 'cmu.edu'
+        assert conflicts[0].tail == '~AreaChair_One1'
+        assert conflicts[1].label == 'mit.edu'
+        assert conflicts[1].tail == '~Reviewer_One1'
+        assert conflicts[2].label == 'umass.edu'
+        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        submissions = conference.get_submissions()
+        assert submissions
+        assert 3 == len(submissions)
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
+        assert tpms_scores
+        assert 15 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.21
+        assert tpms_scores[0].tail == 'r3@fb.com'
+        assert tpms_scores[0].head == submissions[0].id
+        assert tpms_scores[1].weight == 0.31
+        assert tpms_scores[1].tail == 'r3@fb.com'
+        assert tpms_scores[1].head == submissions[1].id
+        assert tpms_scores[2].weight == 0.51
+        assert tpms_scores[2].tail == 'r3@fb.com'
+        assert tpms_scores[2].head == submissions[2].id
+        assert tpms_scores[3].weight == 0.77
+        assert tpms_scores[3].tail == 'r2@google.com'
 
 
     def test_setup_matching_with_subject_areas(self, client, test_client, helpers):
@@ -479,63 +466,54 @@ class TestMatching():
         ))
 
         ## Set up matching
-        metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        # assert metadata_notes
-        # assert len(metadata_notes) == 3
+        conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
 
-        # ## Assert Paper 1 scores
-        # assert metadata_notes[0].forum == blinded_notes[0].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3, 'subjectArea': 0.3333333333333333 }
-        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
-        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        bids = client.get_edges(invitation = conference.get_bid_id())
+        assert bids
+        assert 6 == len(bids)
 
-        # ## Assert Paper 2 scores
-        # assert metadata_notes[1].forum == blinded_notes[1].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2, 'subjectArea': 1  }
-        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
-        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
-        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        recommendations = client.get_edges(invitation = conference.get_recommendation_id())
+        assert recommendations
+        assert 3 == len(recommendations)
 
-        # ## Assert Paper 3 scores
-        # assert metadata_notes[2].forum == blinded_notes[2].id
-        # assert len(metadata_notes[2].content['entries']) == 5
-        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 , 'subjectArea': 0.3333333333333333}
-        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert not custom_loads
+
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert conflicts
+        assert 3 == len(conflicts)
+        assert conflicts[0].label == 'cmu.edu'
+        assert conflicts[0].tail == '~AreaChair_One1'
+        assert conflicts[1].label == 'mit.edu'
+        assert conflicts[1].tail == '~Reviewer_One1'
+        assert conflicts[2].label == 'umass.edu'
+        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        submissions = conference.get_submissions()
+        assert submissions
+        assert 3 == len(submissions)
+
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
+        assert tpms_scores
+        assert 15 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.21
+        assert tpms_scores[0].tail == 'r3@fb.com'
+        assert tpms_scores[0].head == submissions[0].id
+        assert tpms_scores[1].weight == 0.31
+        assert tpms_scores[1].tail == 'r3@fb.com'
+        assert tpms_scores[1].head == submissions[1].id
+        assert tpms_scores[2].weight == 0.51
+        assert tpms_scores[2].tail == 'r3@fb.com'
+        assert tpms_scores[2].head == submissions[2].id
+        assert tpms_scores[3].weight == 0.77
+        assert tpms_scores[3].tail == 'r2@google.com'
+
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Subject_Areas')
+        assert subject_areas_scores
+        assert 3 == len(subject_areas_scores)
+        assert subject_areas_scores[0].tail == '~AreaChair_One1'
+        assert subject_areas_scores[0].weight == 0.3333333333333333
+        assert subject_areas_scores[1].tail == '~AreaChair_One1'
+        assert subject_areas_scores[1].weight == 1
+        assert subject_areas_scores[2].tail == '~AreaChair_One1'
+        assert subject_areas_scores[2].weight == 0.3333333333333333

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -196,12 +196,21 @@ class TestMatching():
         conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
         assert conflicts
         assert 3 == len(conflicts)
-        assert conflicts[0].label == 'cmu.edu'
-        assert conflicts[0].tail == '~AreaChair_One1'
-        assert conflicts[1].label == 'mit.edu'
-        assert conflicts[1].tail == '~Reviewer_One1'
-        assert conflicts[2].label == 'umass.edu'
-        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~AreaChair_One1')
+        assert ac1_conflicts
+        assert len(ac1_conflicts)
+        assert ac1_conflicts[0].label == 'cmu.edu'
+
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~Reviewer_One1')
+        assert r1_conflicts
+        assert len(r1_conflicts)
+        assert r1_conflicts[0].label == 'mit.edu'
+
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = 'ac2@umass.edu')
+        assert ac2_conflicts
+        assert len(ac2_conflicts)
+        assert ac2_conflicts[0].label == 'umass.edu'
 
 
     def test_setup_matching_with_tpms(self, client, test_client, helpers):
@@ -262,12 +271,21 @@ class TestMatching():
         conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
         assert conflicts
         assert 3 == len(conflicts)
-        assert conflicts[0].label == 'cmu.edu'
-        assert conflicts[0].tail == '~AreaChair_One1'
-        assert conflicts[1].label == 'mit.edu'
-        assert conflicts[1].tail == '~Reviewer_One1'
-        assert conflicts[2].label == 'umass.edu'
-        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~AreaChair_One1')
+        assert ac1_conflicts
+        assert len(ac1_conflicts)
+        assert ac1_conflicts[0].label == 'cmu.edu'
+
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~Reviewer_One1')
+        assert r1_conflicts
+        assert len(r1_conflicts)
+        assert r1_conflicts[0].label == 'mit.edu'
+
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = 'ac2@umass.edu')
+        assert ac2_conflicts
+        assert len(ac2_conflicts)
+        assert ac2_conflicts[0].label == 'umass.edu'
 
         submissions = conference.get_submissions()
         assert submissions
@@ -377,13 +395,21 @@ class TestMatching():
 
         conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
         assert conflicts
-        assert 3 == len(conflicts)
-        assert conflicts[0].label == 'cmu.edu'
-        assert conflicts[0].tail == '~AreaChair_One1'
-        assert conflicts[1].label == 'mit.edu'
-        assert conflicts[1].tail == '~Reviewer_One1'
-        assert conflicts[2].label == 'umass.edu'
-        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~AreaChair_One1')
+        assert ac1_conflicts
+        assert len(ac1_conflicts)
+        assert ac1_conflicts[0].label == 'cmu.edu'
+
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~Reviewer_One1')
+        assert r1_conflicts
+        assert len(r1_conflicts)
+        assert r1_conflicts[0].label == 'mit.edu'
+
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = 'ac2@umass.edu')
+        assert ac2_conflicts
+        assert len(ac2_conflicts)
+        assert ac2_conflicts[0].label == 'umass.edu'
 
         submissions = conference.get_submissions()
         assert submissions
@@ -482,12 +508,21 @@ class TestMatching():
         conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
         assert conflicts
         assert 3 == len(conflicts)
-        assert conflicts[0].label == 'cmu.edu'
-        assert conflicts[0].tail == '~AreaChair_One1'
-        assert conflicts[1].label == 'mit.edu'
-        assert conflicts[1].tail == '~Reviewer_One1'
-        assert conflicts[2].label == 'umass.edu'
-        assert conflicts[2].tail == 'ac2@umass.edu'
+
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~AreaChair_One1')
+        assert ac1_conflicts
+        assert len(ac1_conflicts)
+        assert ac1_conflicts[0].label == 'cmu.edu'
+
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = '~Reviewer_One1')
+        assert r1_conflicts
+        assert len(r1_conflicts)
+        assert r1_conflicts[0].label == 'mit.edu'
+
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts', tail = 'ac2@umass.edu')
+        assert ac2_conflicts
+        assert len(ac2_conflicts)
+        assert ac2_conflicts[0].label == 'umass.edu'
 
         submissions = conference.get_submissions()
         assert submissions

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -269,62 +269,24 @@ class TestMatching():
         assert conflicts[2].label == 'umass.edu'
         assert conflicts[2].tail == 'ac2@umass.edu'
 
-        # ## Assert Paper 1 scores
-        # assert metadata_notes[0].forum == blinded_notes[0].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
-        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8 }
-        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        submissions = conference.get_submissions()
+        assert submissions
+        assert 3 == len(submissions)
 
-        # ## Assert Paper 2 scores
-        # assert metadata_notes[1].forum == blinded_notes[1].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
-        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66}
-        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31}
-        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
-
-        # ## Assert Paper 3 scores
-        # assert metadata_notes[2].forum == blinded_notes[2].id
-        # assert len(metadata_notes[2].content['entries']) == 5
-        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
-        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/TPMS')
+        assert tpms_scores
+        assert 15 == len(tpms_scores)
+        assert tpms_scores[0].weight == 0.21
+        assert tpms_scores[0].tail == 'r3@fb.com'
+        assert tpms_scores[0].head == submissions[0].id
+        assert tpms_scores[1].weight == 0.31
+        assert tpms_scores[1].tail == 'r3@fb.com'
+        assert tpms_scores[1].head == submissions[1].id
+        assert tpms_scores[2].weight == 0.51
+        assert tpms_scores[2].tail == 'r3@fb.com'
+        assert tpms_scores[2].head == submissions[2].id
+        assert tpms_scores[3].weight == 0.77
+        assert tpms_scores[3].tail == 'r2@google.com'
 
 
     def test_setup_matching_with_recommendations(self, client, test_client, helpers):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -179,65 +179,65 @@ class TestMatching():
 
         ## Set up matching
         metadata_notes = conference.setup_matching()
-        assert metadata_notes
-        assert len(metadata_notes) == 3
+        # assert metadata_notes
+        # assert len(metadata_notes) == 3
 
-        ## Assert Paper 1 scores
-        assert metadata_notes[0].forum == blinded_notes[2].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1 }
-        assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5 }
-        assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[0].content['entries'][2]['scores'] == {}
-        assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[0].content['entries'][3]['scores'] == {}
-        assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[0].content['entries'][4]['scores'] == {}
-        assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        # ## Assert Paper 1 scores
+        # assert metadata_notes[0].forum == blinded_notes[2].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1 }
+        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5 }
+        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[0].content['entries'][2]['scores'] == {}
+        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[0].content['entries'][3]['scores'] == {}
+        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[0].content['entries'][4]['scores'] == {}
+        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
 
-        ## Assert Paper 2 scores
-        assert metadata_notes[1].forum == blinded_notes[1].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5 }
-        assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1 }
-        assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[1].content['entries'][2]['scores'] == {}
-        assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[1].content['entries'][3]['scores'] == {}
-        assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[1].content['entries'][4]['scores'] == {}
-        assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 2 scores
+        # assert metadata_notes[1].forum == blinded_notes[1].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5 }
+        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1 }
+        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
+        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[1].content['entries'][2]['scores'] == {}
+        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[1].content['entries'][3]['scores'] == {}
+        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[1].content['entries'][4]['scores'] == {}
+        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
 
-        ## Assert Paper 3 scores
-        assert metadata_notes[2].forum == blinded_notes[0].id
-        assert len(metadata_notes[2].content['entries']) == 5
-        assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5 }
-        assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[2].content['entries'][1]['scores'] == {}
-        assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[2].content['entries'][2]['scores'] == {}
-        assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[2].content['entries'][3]['scores'] == {}
-        assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[2].content['entries'][4]['scores'] == {}
-        assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 3 scores
+        # assert metadata_notes[2].forum == blinded_notes[0].id
+        # assert len(metadata_notes[2].content['entries']) == 5
+        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5 }
+        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
+        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[2].content['entries'][1]['scores'] == {}
+        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[2].content['entries'][2]['scores'] == {}
+        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[2].content['entries'][3]['scores'] == {}
+        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[2].content['entries'][4]['scores'] == {}
+        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
 
 
     def test_setup_matching_with_tpms(self, client, test_client, helpers):
@@ -281,67 +281,67 @@ class TestMatching():
 
         ## Set up matching
         metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        assert metadata_notes
-        assert len(metadata_notes) == 3
+        # assert metadata_notes
+        # assert len(metadata_notes) == 3
 
-        blinded_notes = list(conference.get_submissions())
+        # blinded_notes = list(conference.get_submissions())
 
-        ## Assert Paper 1 scores
-        assert metadata_notes[0].forum == blinded_notes[0].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
-        assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8 }
-        assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        # ## Assert Paper 1 scores
+        # assert metadata_notes[0].forum == blinded_notes[0].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
+        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8 }
+        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
+        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
+        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
+        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
 
-        ## Assert Paper 2 scores
-        assert metadata_notes[1].forum == blinded_notes[1].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
-        assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66}
-        assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31}
-        assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 2 scores
+        # assert metadata_notes[1].forum == blinded_notes[1].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
+        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
+        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
+        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66}
+        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31}
+        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
+        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
 
-        ## Assert Paper 3 scores
-        assert metadata_notes[2].forum == blinded_notes[2].id
-        assert len(metadata_notes[2].content['entries']) == 5
-        assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
-        assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 3 scores
+        # assert metadata_notes[2].forum == blinded_notes[2].id
+        # assert len(metadata_notes[2].content['entries']) == 5
+        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
+        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
+        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
+        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
+        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
+        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
+        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
 
 
     def test_setup_matching_with_recommendations(self, client, test_client, helpers):
@@ -412,65 +412,65 @@ class TestMatching():
 
         ## Set up matching
         metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        assert metadata_notes
-        assert len(metadata_notes) == 3
+        # assert metadata_notes
+        # assert len(metadata_notes) == 3
 
-        ## Assert Paper 1 scores
-        assert metadata_notes[0].forum == blinded_notes[0].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
-        assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
-        assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        # ## Assert Paper 1 scores
+        # assert metadata_notes[0].forum == blinded_notes[0].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3 }
+        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
+        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
+        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
+        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
+        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
 
-        ## Assert Paper 2 scores
-        assert metadata_notes[1].forum == blinded_notes[1].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
-        assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
-        assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
-        assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 2 scores
+        # assert metadata_notes[1].forum == blinded_notes[1].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2  }
+        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
+        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
+        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
+        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
+        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
+        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
 
-        ## Assert Paper 3 scores
-        assert metadata_notes[2].forum == blinded_notes[2].id
-        assert len(metadata_notes[2].content['entries']) == 5
-        assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
-        assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 3 scores
+        # assert metadata_notes[2].forum == blinded_notes[2].id
+        # assert len(metadata_notes[2].content['entries']) == 5
+        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 }
+        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
+        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
+        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
+        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
+        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
+        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
 
 
     def test_setup_matching_with_subject_areas(self, client, test_client, helpers):
@@ -535,62 +535,62 @@ class TestMatching():
 
         ## Set up matching
         metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        assert metadata_notes
-        assert len(metadata_notes) == 3
+        # assert metadata_notes
+        # assert len(metadata_notes) == 3
 
-        ## Assert Paper 1 scores
-        assert metadata_notes[0].forum == blinded_notes[0].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3, 'subjectArea': 0.3333333333333333 }
-        assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
-        assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
-        assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
-        assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
-        assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        # ## Assert Paper 1 scores
+        # assert metadata_notes[0].forum == blinded_notes[0].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1, 'tpms': 0.3, 'subjectArea': 0.3333333333333333 }
+        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5, 'tpms': 0.8, 'recommendation': 1 }
+        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[0].content['entries'][2]['scores'] == {'tpms': 0.77}
+        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[0].content['entries'][3]['scores'] == {'tpms': 0.21}
+        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[0].content['entries'][4]['scores'] == {'tpms': 0.6}
+        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
 
-        ## Assert Paper 2 scores
-        assert metadata_notes[1].forum == blinded_notes[1].id
-        assert len(metadata_notes[0].content['entries']) == 5
-        assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2, 'subjectArea': 1  }
-        assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
-        assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
-        assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
-        assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
-        assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 2 scores
+        # assert metadata_notes[1].forum == blinded_notes[1].id
+        # assert len(metadata_notes[0].content['entries']) == 5
+        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5, 'tpms': 0.2, 'subjectArea': 1  }
+        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1, 'tpms': 0.8  }
+        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
+        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[1].content['entries'][2]['scores'] == {'tpms': 0.66, 'recommendation': 1}
+        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[1].content['entries'][3]['scores'] == {'tpms': 0.31, 'recommendation': 0.75}
+        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[1].content['entries'][4]['scores'] == {'tpms': 0.5}
+        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
 
-        ## Assert Paper 3 scores
-        assert metadata_notes[2].forum == blinded_notes[2].id
-        assert len(metadata_notes[2].content['entries']) == 5
-        assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 , 'subjectArea': 0.3333333333333333}
-        assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
-        assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
-        assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
-        assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
-        assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        # ## Assert Paper 3 scores
+        # assert metadata_notes[2].forum == blinded_notes[2].id
+        # assert len(metadata_notes[2].content['entries']) == 5
+        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
+        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5, 'tpms': 0.1 , 'subjectArea': 0.3333333333333333}
+        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
+        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
+        # assert metadata_notes[2].content['entries'][1]['scores'] == {'tpms': 0.8}
+        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
+        # assert metadata_notes[2].content['entries'][2]['scores'] == {'tpms': 0.55}
+        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
+        # assert metadata_notes[2].content['entries'][3]['scores'] == {'tpms': 0.51}
+        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
+        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
+        # assert metadata_notes[2].content['entries'][4]['scores'] == {'tpms': 0.4}
+        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -244,11 +244,30 @@ class TestMatching():
         assert conference, 'conference is None'
 
         ## Set up matching
-        metadata_notes = conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
-        # assert metadata_notes
-        # assert len(metadata_notes) == 3
+        conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
 
-        # blinded_notes = list(conference.get_submissions())
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Assignment_Configuration')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Aggregate_Score')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Paper_Assignment')
+
+        bids = client.get_edges(invitation = conference.get_bid_id())
+        assert bids
+        assert 6 == len(bids)
+
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert not custom_loads
+
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert conflicts
+        assert 3 == len(conflicts)
+        assert conflicts[0].label == 'cmu.edu'
+        assert conflicts[0].tail == '~AreaChair_One1'
+        assert conflicts[1].label == 'mit.edu'
+        assert conflicts[1].tail == '~Reviewer_One1'
+        assert conflicts[2].label == 'umass.edu'
+        assert conflicts[2].tail == 'ac2@umass.edu'
 
         # ## Assert Paper 1 scores
         # assert metadata_notes[0].forum == blinded_notes[0].id

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -178,66 +178,30 @@ class TestMatching():
         ))
 
         ## Set up matching
-        metadata_notes = conference.setup_matching()
-        # assert metadata_notes
-        # assert len(metadata_notes) == 3
+        conference.setup_matching()
 
-        # ## Assert Paper 1 scores
-        # assert metadata_notes[0].forum == blinded_notes[2].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[0].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[0].content['entries'][0]['scores'] == { 'bid': -1 }
-        # assert metadata_notes[0].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[0].content['entries'][1]['scores'] == { 'bid': -0.5 }
-        # assert metadata_notes[0].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[0].content['entries'][2]['scores'] == {}
-        # assert metadata_notes[0].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[0].content['entries'][3]['scores'] == {}
-        # assert metadata_notes[0].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[0].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[0].content['entries'][4]['scores'] == {}
-        # assert metadata_notes[0].content['entries'][4]['conflicts'] == [ 'umass.edu' ]
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Assignment_Configuration')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Aggregate_Score')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Paper_Assignment')
 
-        # ## Assert Paper 2 scores
-        # assert metadata_notes[1].forum == blinded_notes[1].id
-        # assert len(metadata_notes[0].content['entries']) == 5
-        # assert metadata_notes[1].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[1].content['entries'][0]['scores'] == { 'bid': -0.5 }
-        # assert metadata_notes[1].content['entries'][0].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[1].content['entries'][1]['scores'] == { 'bid': 1 }
-        # assert metadata_notes[1].content['entries'][1]['conflicts'] == [ 'mit.edu' ]
-        # assert metadata_notes[1].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[1].content['entries'][2]['scores'] == {}
-        # assert metadata_notes[1].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[1].content['entries'][3]['scores'] == {}
-        # assert metadata_notes[1].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[1].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[1].content['entries'][4]['scores'] == {}
-        # assert metadata_notes[1].content['entries'][4].get('conflicts') is None
+        bids = client.get_edges(invitation = conference.get_bid_id())
+        assert bids
+        assert 6 == len(bids)
 
-        # ## Assert Paper 3 scores
-        # assert metadata_notes[2].forum == blinded_notes[0].id
-        # assert len(metadata_notes[2].content['entries']) == 5
-        # assert metadata_notes[2].content['entries'][0]['userid'] == '~AreaChair_One1'
-        # assert metadata_notes[2].content['entries'][0]['scores'] == { 'bid': 0.5 }
-        # assert metadata_notes[2].content['entries'][0]['conflicts'] == [ 'cmu.edu' ]
-        # assert metadata_notes[2].content['entries'][1]['userid'] == '~Reviewer_One1'
-        # assert metadata_notes[2].content['entries'][1]['scores'] == {}
-        # assert metadata_notes[2].content['entries'][1].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][2]['userid'] == 'r2@google.com'
-        # assert metadata_notes[2].content['entries'][2]['scores'] == {}
-        # assert metadata_notes[2].content['entries'][2].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][3]['userid'] == 'r3@fb.com'
-        # assert metadata_notes[2].content['entries'][3]['scores'] == {}
-        # assert metadata_notes[2].content['entries'][3].get('conflicts') is None
-        # assert metadata_notes[2].content['entries'][4]['userid'] == 'ac2@umass.edu'
-        # assert metadata_notes[2].content['entries'][4]['scores'] == {}
-        # assert metadata_notes[2].content['entries'][4].get('conflicts') is None
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Custom_Load')
+        assert not custom_loads
+
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Conflicts')
+        assert conflicts
+        assert 3 == len(conflicts)
+        assert conflicts[0].label == 'cmu.edu'
+        assert conflicts[0].tail == '~AreaChair_One1'
+        assert conflicts[1].label == 'mit.edu'
+        assert conflicts[1].tail == '~Reviewer_One1'
+        assert conflicts[2].label == 'umass.edu'
+        assert conflicts[2].tail == 'ac2@umass.edu'
 
 
     def test_setup_matching_with_tpms(self, client, test_client, helpers):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -126,43 +126,55 @@ class TestMatching():
         conference.set_authors()
 
         ac1_client = helpers.create_user('ac1@cmu.edu', 'AreaChair', 'One')
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[0].id,
-            tag = 'High'
+            head = blinded_notes[0].id,
+            tail = '~AreaChair_One1',
+            label = 'High'
         ))
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[1].id,
-            tag = 'Low'
+            head = blinded_notes[1].id,
+            tail = '~AreaChair_One1',
+            label = 'Low'
         ))
-        ac1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
-            forum = blinded_notes[2].id,
-            tag = 'Very Low'
+            head = blinded_notes[2].id,
+            tail = '~AreaChair_One1',
+            label = 'Very Low'
         ))
 
         r1_client = helpers.create_user('r1@mit.edu', 'Reviewer', 'One')
-        r1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
-            forum = blinded_notes[0].id,
-            tag = 'Neutral'
+            head = blinded_notes[0].id,
+            tail = '~Reviewer_One1',
+            label = 'Neutral'
         ))
-        r1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
-            forum = blinded_notes[1].id,
-            tag = 'Very High'
+            head = blinded_notes[1].id,
+            tail = '~Reviewer_One1',
+            label = 'Very High'
         ))
-        r1_client.post_tag(openreview.Tag(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
+            writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
-            forum = blinded_notes[2].id,
-            tag = 'Low'
+            head = blinded_notes[2].id,
+            tail = '~Reviewer_One1',
+            label = 'Low'
         ))
 
         ## Set up matching


### PR DESCRIPTION
It depends on: https://github.com/iesl/openreview/pull/1467

- Adapts bid and recommendation invitation to be edge invitations following the spec.
- Adapts ```setup_matching``` to work with edges instead of the metadata notes. The builder computes: conflicts, custom loads, TPMS, Affinity and subject areas scores. 
- Setup default score specification for all the available score invitations.
- Deploy the assignments reading the paper assignments edges.
- Implements delete edges.
- Refactor post bulk edges, moved to the tools module.
- Fix tests.

@marshall62 you can use the builder to setup the full conference, no need to create your own edges to test.

@zbialecki running:

```
pytest tests/test_matching.py
```

gives you a UAI venue with bids, recommendation, tpms and subject areas edges. Also you could run the matcher and get paper assignment and aggregate scores. 