### PR TITLE
Feature/adding stages

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -371,14 +371,14 @@ class Conference(object):
         if not self.submission_stage.double_blind:
             raise openreview.OpenReviewException('Conference is not double blind')
 
-        submissions_by_original = { note.original: note.id for note in self.get_submissions() }
+        submissions_by_original = { note.original: note for note in self.get_submissions() }
 
         self.invitation_builder.set_blind_submission_invitation(self)
-        new_blinded_notes = []
+        blinded_notes = []
 
         for note in tools.iterget_notes(self.client, invitation = self.get_submission_id(), sort = 'number:asc'):
-            note_id = submissions_by_original.get(note.id)
-            if not note_id:
+            blind_note = submissions_by_original.get(note.id)
+            if not blind_note:
                 blind_note = openreview.Note(
                     id = None,
                     original= note.id,
@@ -393,22 +393,22 @@ class Conference(object):
                         "_bibtex": None
                     })
 
-                posted_blind_note = self.client.post_note(blind_note)
+                blind_note = self.client.post_note(blind_note)
 
-                posted_blind_note.readers = self.submission_stage.get_blind_readers(self, posted_blind_note.number)
+                blind_note.readers = self.submission_stage.get_blind_readers(self, blind_note.number)
 
-                posted_blind_note.content = {
-                    'authorids': [self.get_authors_id(number = posted_blind_note.number)],
+                blind_note.content = {
+                    'authorids': [self.get_authors_id(number = blind_note.number)],
                     'authors': ['Anonymous'],
                     '_bibtex': None #Create bibtext automatically
                 }
 
-                posted_blind_note = self.client.post_note(posted_blind_note)
-                new_blinded_notes.append(posted_blind_note)
+                blind_note = self.client.post_note(blind_note)
+            blinded_notes.append(blind_note)
 
         # Update page with double blind submissions
         self.__set_program_chair_page()
-        return new_blinded_notes
+        return blinded_notes
 
     ## Deprecated
     def open_bids(self):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -374,40 +374,41 @@ class Conference(object):
         submissions_by_original = { note.original: note.id for note in self.get_submissions() }
 
         self.invitation_builder.set_blind_submission_invitation(self)
-        blinded_notes = []
+        new_blinded_notes = []
 
         for note in tools.iterget_notes(self.client, invitation = self.get_submission_id(), sort = 'number:asc'):
             note_id = submissions_by_original.get(note.id)
-            blind_note = openreview.Note(
-                id = note_id,
-                original= note.id,
-                invitation= self.get_blind_submission_id(),
-                forum=None,
-                signatures= [self.id],
-                writers= [self.id],
-                readers= [self.id],
-                content= {
-                    "authors": ['Anonymous'],
-                    "authorids": [self.id],
-                    "_bibtex": None
-                })
+            if not note_id:
+                blind_note = openreview.Note(
+                    id = None,
+                    original= note.id,
+                    invitation= self.get_blind_submission_id(),
+                    forum=None,
+                    signatures= [self.id],
+                    writers= [self.id],
+                    readers= [self.id],
+                    content= {
+                        "authors": ['Anonymous'],
+                        "authorids": [self.id],
+                        "_bibtex": None
+                    })
 
-            posted_blind_note = self.client.post_note(blind_note)
+                posted_blind_note = self.client.post_note(blind_note)
 
-            posted_blind_note.readers = self.submission_stage.get_blind_readers(self, posted_blind_note.number)
+                posted_blind_note.readers = self.submission_stage.get_blind_readers(self, posted_blind_note.number)
 
-            posted_blind_note.content = {
-                'authorids': [self.get_authors_id(number = posted_blind_note.number)],
-                'authors': ['Anonymous'],
-                '_bibtex': None #Create bibtext automatically
-            }
+                posted_blind_note.content = {
+                    'authorids': [self.get_authors_id(number = posted_blind_note.number)],
+                    'authors': ['Anonymous'],
+                    '_bibtex': None #Create bibtext automatically
+                }
 
-            posted_blind_note = self.client.post_note(posted_blind_note)
-            blinded_notes.append(posted_blind_note)
+                posted_blind_note = self.client.post_note(posted_blind_note)
+                new_blinded_notes.append(posted_blind_note)
 
         # Update page with double blind submissions
         self.__set_program_chair_page()
-        return blinded_notes
+        return new_blinded_notes
 
     ## Deprecated
     def open_bids(self):

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -73,87 +73,83 @@ def get_conference(client, request_form_id):
     conference.set_program_chairs(emails = note.content['Contact Emails'])
     return conference
 
-def get_bid_stage(client, request_form_id):
-    note = client.get_note(request_form_id)
+def get_bid_stage(client, request_forum):
     bid_start_date = None
-    if note.content.get('bid_start_date', None):
+    if request_forum.content.get('bid_start_date', None):
         try:
-            bid_start_date = datetime.datetime.strptime(note.content.get('bid_start_date', None), '%Y/%m/%d %H:%M')
+            bid_start_date = datetime.datetime.strptime(request_forum.content.get('bid_start_date', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            bid_start_date = datetime.datetime.strptime(note.content.get('bid_start_date', None), '%Y/%m/%d')
+            bid_start_date = datetime.datetime.strptime(request_forum.content.get('bid_start_date', None), '%Y/%m/%d')
 
     bid_due_date = None
-    if note.content.get('bid_due_date', None):
+    if request_forum.content.get('bid_due_date', None):
         try:
-            bid_due_date = datetime.datetime.strptime(note.content.get('bid_due_date'), '%Y/%m/%d %H:%M')
+            bid_due_date = datetime.datetime.strptime(request_forum.content.get('bid_due_date'), '%Y/%m/%d %H:%M')
         except ValueError:
-            bid_due_date = datetime.datetime.strptime(note.content.get('bid_due_date'), '%Y/%m/%d')
+            bid_due_date = datetime.datetime.strptime(request_forum.content.get('bid_due_date'), '%Y/%m/%d')
 
-    return openreview.BidStage(start_date = bid_start_date, due_date = bid_due_date, request_count = note.content.get('bid_count', 50))
+    return openreview.BidStage(start_date = bid_start_date, due_date = bid_due_date, request_count = request_forum.content.get('bid_count', 50))
 
-def get_review_stage(client, request_form_id):
-    note = client.get_note(request_form_id)
+def get_review_stage(client, request_forum):
     review_start_date = None
-    if note.content.get('review_start_date', None):
+    if request_forum.content.get('review_start_date', None):
         try:
-            review_start_date = datetime.datetime.strptime(note.content.get('review_start_date', None), '%Y/%m/%d %H:%M')
+            review_start_date = datetime.datetime.strptime(request_forum.content.get('review_start_date', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            review_start_date = datetime.datetime.strptime(note.content.get('review_start_date', None), '%Y/%m/%d')
+            review_start_date = datetime.datetime.strptime(request_forum.content.get('review_start_date', None), '%Y/%m/%d')
 
     review_due_date = None
-    if note.content.get('review_deadline', None):
+    if request_forum.content.get('review_deadline', None):
         try:
-            review_due_date = datetime.datetime.strptime(note.content.get('review_deadline', None), '%Y/%m/%d %H:%M')
+            review_due_date = datetime.datetime.strptime(request_forum.content.get('review_deadline', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            review_due_date = datetime.datetime.strptime(note.content.get('review_deadline', None), '%Y/%m/%d')
+            review_due_date = datetime.datetime.strptime(request_forum.content.get('review_deadline', None), '%Y/%m/%d')
 
-    review_additional_fields = note.content.get('additional_review_options', {})
+    review_additional_fields = request_forum.content.get('additional_review_options', {})
     if review_additional_fields:
         review_additional_fields = json.loads(review_additional_fields)
 
-    return openreview.ReviewStage(start_date = review_start_date, due_date = review_due_date, allow_de_anonymization = (note.content.get('Author and Reviewer Anonymity', None) == 'No anonymity'), public = (note.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.'), release_to_authors = (note.content.get('release_reviews_to_authors', False) == 'Yes'), release_to_reviewers = (note.content.get('release_reviews_to_reviewers', False) == 'Yes'), email_pcs = (note.content.get('email_program_Chairs_about_reviews', False) == 'Yes'), additional_fields = review_additional_fields)
+    return openreview.ReviewStage(start_date = review_start_date, due_date = review_due_date, allow_de_anonymization = (request_forum.content.get('Author and Reviewer Anonymity', None) == 'No anonymity'), public = (request_forum.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.'), release_to_authors = (request_forum.content.get('release_reviews_to_authors', False) == 'Yes'), release_to_reviewers = (request_forum.content.get('release_reviews_to_reviewers', False) == 'Yes'), email_pcs = (request_forum.content.get('email_program_Chairs_about_reviews', False) == 'Yes'), additional_fields = review_additional_fields)
 
-def get_meta_review_stage(client, request_form_id):
-    note = client.get_note(request_form_id)
+def get_meta_review_stage(client, request_forum):
     meta_review_start_date = None
-    if note.content.get('meta_review_start_date', None):
+    if request_forum.content.get('meta_review_start_date', None):
         try:
-            meta_review_start_date = datetime.datetime.strptime(note.content.get('meta_review_start_date', None), '%Y/%m/%d %H:%M')
+            meta_review_start_date = datetime.datetime.strptime(request_forum.content.get('meta_review_start_date', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            meta_review_start_date = datetime.datetime.strptime(note.content.get('meta_review_start_date', None), '%Y/%m/%d')
+            meta_review_start_date = datetime.datetime.strptime(request_forum.content.get('meta_review_start_date', None), '%Y/%m/%d')
 
     meta_review_due_date = None
-    if note.content.get('meta_review_deadline', None):
+    if request_forum.content.get('meta_review_deadline', None):
         try:
-            meta_review_due_date = datetime.datetime.strptime(note.content.get('meta_review_deadline', None), '%Y/%m/%d %H:%M')
+            meta_review_due_date = datetime.datetime.strptime(request_forum.content.get('meta_review_deadline', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            meta_review_due_date = datetime.datetime.strptime(note.content.get('meta_review_deadline', None), '%Y/%m/%d')
+            meta_review_due_date = datetime.datetime.strptime(request_forum.content.get('meta_review_deadline', None), '%Y/%m/%d')
 
-    meta_review_additional_fields = note.content.get('additional_meta_review_options', {})
+    meta_review_additional_fields = request_forum.content.get('additional_meta_review_options', {})
     if meta_review_additional_fields:
         meta_review_additional_fields = json.loads(meta_review_additional_fields)
 
-    return openreview.MetaReviewStage(start_date = meta_review_start_date, due_date = meta_review_due_date, public = (note.content.get('make_meta_reviews_public', None) == 'Yes'), additional_fields = meta_review_additional_fields)
+    return openreview.MetaReviewStage(start_date = meta_review_start_date, due_date = meta_review_due_date, public = (request_forum.content.get('make_meta_reviews_public', None) == 'Yes'), additional_fields = meta_review_additional_fields)
 
-def get_decision_stage(client, request_form_id):
-    note = client.get_note(request_form_id)
+def get_decision_stage(client, request_forum):
     decision_start_date = None
-    if note.content.get('decision_start_date', None):
+    if request_forum.content.get('decision_start_date', None):
         try:
-            decision_start_date = datetime.datetime.strptime(note.content.get('decision_start_date', None), '%Y/%m/%d %H:%M')
+            decision_start_date = datetime.datetime.strptime(request_forum.content.get('decision_start_date', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            decision_start_date = datetime.datetime.strptime(note.content.get('decision_start_date', None), '%Y/%m/%d')
+            decision_start_date = datetime.datetime.strptime(request_forum.content.get('decision_start_date', None), '%Y/%m/%d')
 
     decision_due_date = None
-    if note.content.get('decision_deadline', None):
+    if request_forum.content.get('decision_deadline', None):
         try:
-            decision_due_date = datetime.datetime.strptime(note.content.get('decision_deadline', None), '%Y/%m/%d %H:%M')
+            decision_due_date = datetime.datetime.strptime(request_forum.content.get('decision_deadline', None), '%Y/%m/%d %H:%M')
         except ValueError:
-            decision_due_date = datetime.datetime.strptime(note.content.get('decision_deadline', None), '%Y/%m/%d')
+            decision_due_date = datetime.datetime.strptime(request_forum.content.get('decision_deadline', None), '%Y/%m/%d')
 
-    decision_options = note.content.get('decision_options', None)
+    decision_options = request_forum.content.get('decision_options', None)
     if decision_options:
         decision_options = [s.translate(str.maketrans('', '', '"\'')).strip() for s in decision_options.split(',')]
-        return openreview.DecisionStage(options = decision_options, start_date = decision_start_date, due_date = decision_due_date, public = (note.content.get('make_decisions_public', None) == 'Yes'), release_to_authors = (note.content.get('release_decisions_to_authors', None) == 'Yes'), release_to_reviewers = (note.content.get('release_decisions_to_reviewers', None) == 'Yes'))
+        return openreview.DecisionStage(options = decision_options, start_date = decision_start_date, due_date = decision_due_date, public = (request_forum.content.get('make_decisions_public', None) == 'Yes'), release_to_authors = (request_forum.content.get('release_decisions_to_authors', None) == 'Yes'), release_to_reviewers = (request_forum.content.get('release_decisions_to_reviewers', None) == 'Yes'))
     else:
-        return openreview.DecisionStage(start_date = decision_start_date, due_date = decision_due_date, public = (note.content.get('make_decisions_public', None) == 'Yes'))
+        return openreview.DecisionStage(start_date = decision_start_date, due_date = decision_due_date, public = (request_forum.content.get('make_decisions_public', None) == 'Yes'), release_to_authors = (request_forum.content.get('release_decisions_to_authors', None) == 'Yes'), release_to_reviewers = (request_forum.content.get('release_decisions_to_reviewers', None) == 'Yes'))

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -78,3 +78,88 @@ def get_conference(client, request_form_id):
     conference = builder.get_result()
     conference.set_program_chairs(emails = note.content['Contact Emails'])
     return conference
+
+def get_bid_stage(client, request_form_id):
+    note = client.get_note(request_form_id)
+    bid_start_date = None
+    if note.content.get('bid_start_date', None):
+        try:
+            bid_start_date = datetime.datetime.strptime(note.content.get('bid_start_date', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            bid_start_date = datetime.datetime.strptime(note.content.get('bid_start_date', None), '%Y/%m/%d')
+
+    bid_due_date = None
+    if note.content.get('bid_due_date', None):
+        try:
+            bid_due_date = datetime.datetime.strptime(note.content.get('bid_due_date'), '%Y/%m/%d %H:%M')
+        except ValueError:
+            bid_due_date = datetime.datetime.strptime(note.content.get('bid_due_date'), '%Y/%m/%d')
+
+    return openreview.BidStage(start_date = bid_start_date, due_date = bid_due_date, request_count = note.content.get('bid_count', 50))
+
+def get_review_stage(client, request_form_id):
+    note = client.get_note(request_form_id)
+    review_start_date = None
+    if note.content.get('review_start_date', None):
+        try:
+            review_start_date = datetime.datetime.strptime(note.content.get('review_start_date', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            review_start_date = datetime.datetime.strptime(note.content.get('review_start_date', None), '%Y/%m/%d')
+
+    review_due_date = None
+    if note.content.get('review_deadline', None):
+        try:
+            review_due_date = datetime.datetime.strptime(note.content.get('review_deadline', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            review_due_date = datetime.datetime.strptime(note.content.get('review_deadline', None), '%Y/%m/%d')
+
+    review_additional_fields = note.content.get('additional_review_options', {})
+    if review_additional_fields:
+        review_additional_fields = json.loads(review_additional_fields)
+
+    return openreview.ReviewStage(start_date = review_start_date, due_date = review_due_date, allow_de_anonymization = (note.content.get('Author and Reviewer Anonymity', None) == 'No anonymity'), public = (note.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.'), release_to_authors = (note.content.get('release_reviews_to_authors', False) == 'Yes'), release_to_reviewers = (note.content.get('release_reviews_to_reviewers', False) == 'Yes'), email_pcs = (note.content.get('email_program_Chairs_about_reviews', False) == 'Yes'), additional_fields = review_additional_fields)
+
+def get_meta_review_stage(client, request_form_id):
+    note = client.get_note(request_form_id)
+    meta_review_start_date = None
+    if note.content.get('meta_review_start_date', None):
+        try:
+            meta_review_start_date = datetime.datetime.strptime(note.content.get('meta_review_start_date', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            meta_review_start_date = datetime.datetime.strptime(note.content.get('meta_review_start_date', None), '%Y/%m/%d')
+
+    meta_review_due_date = None
+    if note.content.get('meta_review_deadline', None):
+        try:
+            meta_review_due_date = datetime.datetime.strptime(note.content.get('meta_review_deadline', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            meta_review_due_date = datetime.datetime.strptime(note.content.get('meta_review_deadline', None), '%Y/%m/%d')
+
+    meta_review_additional_fields = note.content.get('additional_meta_review_options', {})
+    if meta_review_additional_fields:
+        meta_review_additional_fields = json.loads(meta_review_additional_fields)
+
+    return openreview.MetaReviewStage(start_date = meta_review_start_date, due_date = meta_review_due_date, public = (note.content.get('make_meta_reviews_public', None) == 'Yes'), additional_fields = meta_review_additional_fields)
+
+def get_decision_stage(client, request_form_id):
+    note = client.get_note(request_form_id)
+    decision_start_date = None
+    if note.content.get('decision_start_date', None):
+        try:
+            decision_start_date = datetime.datetime.strptime(note.content.get('decision_start_date', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            decision_start_date = datetime.datetime.strptime(note.content.get('decision_start_date', None), '%Y/%m/%d')
+
+    decision_due_date = None
+    if note.content.get('decision_deadline', None):
+        try:
+            decision_due_date = datetime.datetime.strptime(note.content.get('decision_deadline', None), '%Y/%m/%d %H:%M')
+        except ValueError:
+            decision_due_date = datetime.datetime.strptime(note.content.get('decision_deadline', None), '%Y/%m/%d')
+
+    decision_options = note.content.get('decision_options', None)
+    if decision_options:
+        decision_options = [s.translate(str.maketrans('', '', '"\'')).strip() for s in decision_options.split(',')]
+        return openreview.DecisionStage(options = decision_options, start_date = decision_start_date, due_date = decision_due_date, public = (note.content.get('make_decisions_public', None) == 'Yes'), release_to_authors = (note.content.get('release_decisions_to_authors', None) == 'Yes'), release_to_reviewers = (note.content.get('release_decisions_to_reviewers', None) == 'Yes'))
+    else:
+        return openreview.DecisionStage(start_date = decision_start_date, due_date = decision_due_date, public = (note.content.get('make_decisions_public', None) == 'Yes'))

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -641,22 +641,12 @@ class TestDoubleBlindConference():
         assert len(blind_submissions) == 1
 
         blind_submissions_2 = conference.create_blind_submissions()
-        assert blind_submissions_2
-        assert len(blind_submissions_2) == 1
-        assert blind_submissions[0].id == blind_submissions_2[0].id
-        assert blind_submissions_2[0].readers == [
-            'AKBC.ws/2019/Conference/Paper1/Authors',
-            'AKBC.ws/2019/Conference/Reviewers',
-            'AKBC.ws/2019/Conference/Area_Chairs',
-            'AKBC.ws/2019/Conference/Program_Chairs']
+        assert len(blind_submissions_2) == 0
 
         builder.set_submission_stage(public = True, double_blind= True)
         conference = builder.get_result()
         blind_submissions_3 = conference.create_blind_submissions()
-        assert blind_submissions_3
-        assert len(blind_submissions_3) == 1
-        assert blind_submissions[0].id == blind_submissions_3[0].id
-        assert blind_submissions_3[0].readers == ['everyone']
+        assert len(blind_submissions_3) == 0
 
     def test_open_comments(self, client, test_client, selenium, request_page):
 


### PR DESCRIPTION
Logic for stages shifted to helpers. These functions to enable/update stages can be called from processes.
In the builder, the method create_blind_submissions() has been modified to only create blinded notes for original notes without any blinded notes. The behavior initially was to create/update blind notes for all original notes every time the method is invoked. 
Please note that the method still return all the blind notes in the system for the given conference.