### PR TITLE
removed additional options from helpers & fix for set_area_chairs

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -472,9 +472,14 @@ class Conference(object):
         self.__create_group(self.id, '~Super_User1', [self.get_program_chairs_id()])
         return self.__set_program_chair_page()
 
-    def set_area_chairs(self, emails):
+    def set_area_chairs(self, emails = []):
         if self.use_area_chairs:
             self.__create_group(self.get_area_chairs_id(), self.id, emails)
+
+            notes_iterator = self.get_submissions()
+            for n in notes_iterator:
+                self.__create_group(self.get_area_chairs_id(number = n.number), self.id)
+
             return self.__set_area_chair_page()
         else:
             raise openreview.OpenReviewException('Conference "has_area_chairs" setting is disabled')

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -105,11 +105,7 @@ def get_review_stage(client, request_forum):
         except ValueError:
             review_due_date = datetime.datetime.strptime(request_forum.content.get('review_deadline', None), '%Y/%m/%d')
 
-    review_additional_fields = request_forum.content.get('additional_review_options', {})
-    if review_additional_fields:
-        review_additional_fields = json.loads(review_additional_fields)
-
-    return openreview.ReviewStage(start_date = review_start_date, due_date = review_due_date, allow_de_anonymization = (request_forum.content.get('Author and Reviewer Anonymity', None) == 'No anonymity'), public = (request_forum.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.'), release_to_authors = (request_forum.content.get('release_reviews_to_authors', False) == 'Yes'), release_to_reviewers = (request_forum.content.get('release_reviews_to_reviewers', False) == 'Yes'), email_pcs = (request_forum.content.get('email_program_Chairs_about_reviews', False) == 'Yes'), additional_fields = review_additional_fields)
+    return openreview.ReviewStage(start_date = review_start_date, due_date = review_due_date, allow_de_anonymization = (request_forum.content.get('Author and Reviewer Anonymity', None) == 'No anonymity'), public = (request_forum.content.get('Open Reviewing Policy', None) == 'Submissions and reviews should both be public.'), release_to_authors = (request_forum.content.get('release_reviews_to_authors', False) == 'Yes'), release_to_reviewers = (request_forum.content.get('release_reviews_to_reviewers', False) == 'Yes'), email_pcs = (request_forum.content.get('email_program_Chairs_about_reviews', False) == 'Yes'))
 
 def get_meta_review_stage(client, request_forum):
     meta_review_start_date = None
@@ -126,11 +122,7 @@ def get_meta_review_stage(client, request_forum):
         except ValueError:
             meta_review_due_date = datetime.datetime.strptime(request_forum.content.get('meta_review_deadline', None), '%Y/%m/%d')
 
-    meta_review_additional_fields = request_forum.content.get('additional_meta_review_options', {})
-    if meta_review_additional_fields:
-        meta_review_additional_fields = json.loads(meta_review_additional_fields)
-
-    return openreview.MetaReviewStage(start_date = meta_review_start_date, due_date = meta_review_due_date, public = (request_forum.content.get('make_meta_reviews_public', None) == 'Yes'), additional_fields = meta_review_additional_fields)
+    return openreview.MetaReviewStage(start_date = meta_review_start_date, due_date = meta_review_due_date, public = (request_forum.content.get('make_meta_reviews_public', None) == 'Yes'))
 
 def get_decision_stage(client, request_forum):
     decision_start_date = None


### PR DESCRIPTION
1. We removed the options to provide additional fields through the request form as providing json can get confusing for Program Chairs. This PR removes some dead code created in the helpers.py because of that change.

(Note that a json can still be provided to implement custom fields for the submission form through the revision invitation.)

2. This PR also has a fix for set_area_chairs() function which will now accept emails as an optional argument and create ac groups for each submission (similar to set_reviewers)