### PR TITLE
Feature/groupby edges query

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -206,6 +206,12 @@ class Matching(object):
                         'description': 'Min number of reviews a person should do',
                         'order': 5
                     },
+                    'alternates': {
+                        'value-regex': '[0-9]+',
+                        'required': True,
+                        'description': 'The best N percent (expressed as an integer) of scores that result in generating aggregate score edges that can be used for selecting alternates',
+                        'order': 5
+                    },
                     'paper_invitation': {
                         'value': self.conference.get_blind_submission_id(),
                         'required': True,

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -13,7 +13,7 @@ import os
 import getpass
 import re
 import datetime
-
+from collections import defaultdict
 
 
 class OpenReviewException(Exception):
@@ -565,6 +565,19 @@ class Client(object):
         response = self.__handle_response(response)
 
         return [Edge.from_json(t) for t in response.json()['edges']]
+
+    def get_edges_group (self, invitation, groupby='head', project='tail', limit=1000):
+        params = {}
+        params['id'] = None
+        params['invitation'] = invitation
+        params['groupBy'] = groupby
+        params['project'] = project
+        params['limit'] = limit
+        response = requests.get(self.edges_url, params = params, headers = self.headers)
+        response = self.__handle_response(response)
+        json = response.json()
+        return json
+
 
     def post_group(self, group, overwrite = True):
         """

--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -566,17 +566,30 @@ class Client(object):
 
         return [Edge.from_json(t) for t in response.json()['edges']]
 
-    def get_edges_group (self, invitation, groupby='head', project='tail', limit=1000):
+    def get_edges_group (self, invitation, groupby='head', select='tail', limit=None, offset=None):
+        '''
+        Returns a list of JSON objects where each one represents a group of edges.  For example calling this
+        method with default arguments will give back a list of groups where each group is of the form:
+        {id: {head: paper-1} values: [ {tail: user-1}, {tail: user-2} ]}
+        Note: The limit applies to the number of groups returned.  It does not apply to the number of edges within the groups.
+        :param invitation:
+        :param groupby:
+        :param select:
+        :param limit:
+        :param offset:
+        :return:
+        '''
         params = {}
         params['id'] = None
         params['invitation'] = invitation
         params['groupBy'] = groupby
-        params['project'] = project
+        params['select'] = select
         params['limit'] = limit
+        params['offset'] = offset
         response = requests.get(self.edges_url, params = params, headers = self.headers)
         response = self.__handle_response(response)
         json = response.json()
-        return json
+        return json['groupedEdges'] # a list of JSON objects holding information about an edge
 
 
     def post_group(self, group, overwrite = True):


### PR DESCRIPTION
A new API method to support groupBy edge queries.    
Also adds "alternates" field to the config invitation built by the matching module.  This holds a number which is the percentage of top scores for each paper that should be generated as aggregate_score edges.   These top N% of each paper's reviewers forms the set of alternates reviewers.

-- It was necessary to create the get_edges_group method because when I tried creating a similar function in the matcher rather than in openreview.Client, the results coming back from openreview were status of 200 but no JSON.  The headers were correct (taken from the openreview.Client), so I couldn't figure out what it didn't like and, ultimately, we're going to want an API method to do this anyway.