### PR TITLE
enable profile search by name, previously only available in deprecate…

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -343,7 +343,7 @@ class Client(object):
         response = self.__handle_response(response)
         return [Profile.from_json(p) for p in response.json()['profiles']]
 
-    def search_profiles(self, emails = None, ids = None, term = None):
+    def search_profiles(self, emails = None, ids = None, term = None, first = None, middle = None, last = None):
         """
         Gets a list of profiles using either their ids or corresponding emails
 
@@ -373,6 +373,12 @@ class Client(object):
             response = requests.post(self.profiles_search_url, json = {'ids': ids}, headers = self.headers)
             response = self.__handle_response(response)
             return [Profile.from_json(p) for p in response.json()['profiles']]
+
+        if first or middle or last:
+            response = requests.get(self.profiles_url, params = {'first': first, 'middle': middle, 'last': last}, headers = self.headers)
+            response = self.__handle_response(response)
+            return [Profile.from_json(p) for p in response.json()['profiles']]
+
 
         return []
 


### PR DESCRIPTION
…d function.

Let me know if there's a better way to handle this. I tried using the "term" parameter, but it only returns exact matches.

Amanda Stent will need this when searching for profiles.

Examples:

```
client.search_profiles(term="Aaron Courville") 
# returns profile "~Aaron_Courville3"

client.search_profiles(first="Aaron", last="Courville") 
# correctly returns profiles "~Aaron_Courville3" and "~Aaron_C._Courville1"
```