### PR TITLE
Feature/edges patch add matching group

### DIFF
--- a/openreview/openreview.py
+++ b/openreview/openreview.py
@@ -673,6 +673,21 @@ class Client(object):
 
         return [Note.from_json(n) for n in response.json()['notes']]
 
+    def get_reference(self, id):
+        """
+        Get a single reference by id if available
+
+        :param id: id of the reference
+        :type id: str
+
+        :return: reference matching the passed id
+        :rtype: Note
+        """
+        response = requests.get(self.reference_url, params = {'id':id}, headers = self.headers)
+        response = self.__handle_response(response)
+        n = response.json()['references'][0]
+        return Note.from_json(n)
+
     def get_references(self, referent = None, invitation = None, mintcdate = None, limit = None, offset = None, original = False):
         """
         Gets a list of revisions for a note. The revisions that will be returned match all the criteria passed in the parameters.

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -180,34 +180,34 @@ class TestMatching():
         ## Set up matching
         conference.setup_matching()
 
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Assignment_Configuration')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Aggregate_Score')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Paper_Assignment')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Assignment_Configuration')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Aggregate_Score')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Paper_Assignment')
 
         bids = client.get_edges(invitation = conference.get_bid_id())
         assert bids
         assert 6 == len(bids)
 
-        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
         assert not custom_loads
 
-        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
         assert conflicts
         assert 3 == len(conflicts)
 
-        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~AreaChair_One1')
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~AreaChair_One1')
         assert ac1_conflicts
         assert len(ac1_conflicts)
         assert ac1_conflicts[0].label == 'cmu.edu'
 
-        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~Reviewer_One1')
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~Reviewer_One1')
         assert r1_conflicts
         assert len(r1_conflicts)
         assert r1_conflicts[0].label == 'mit.edu'
 
-        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = 'ac2@umass.edu')
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = 'ac2@umass.edu')
         assert ac2_conflicts
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'umass.edu'
@@ -255,34 +255,34 @@ class TestMatching():
         ## Set up matching
         conference.setup_matching(tpms_score_file= os.path.join(os.path.dirname(__file__), 'data/tpms_scores.csv'))
 
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Assignment_Configuration')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Aggregate_Score')
-        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/-/Reviewing/Paper_Assignment')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Assignment_Configuration')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Aggregate_Score')
+        assert client.get_invitation(id = 'auai.org/UAI/2019/Conference/Matching/-/Paper_Assignment')
 
         bids = client.get_edges(invitation = conference.get_bid_id())
         assert bids
         assert 6 == len(bids)
 
-        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
         assert not custom_loads
 
-        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
         assert conflicts
         assert 3 == len(conflicts)
 
-        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~AreaChair_One1')
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~AreaChair_One1')
         assert ac1_conflicts
         assert len(ac1_conflicts)
         assert ac1_conflicts[0].label == 'cmu.edu'
 
-        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~Reviewer_One1')
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~Reviewer_One1')
         assert r1_conflicts
         assert len(r1_conflicts)
         assert r1_conflicts[0].label == 'mit.edu'
 
-        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = 'ac2@umass.edu')
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = 'ac2@umass.edu')
         assert ac2_conflicts
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'umass.edu'
@@ -291,21 +291,21 @@ class TestMatching():
         assert submissions
         assert 3 == len(submissions)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score')
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score')
         assert tpms_scores
         assert 15 == len(tpms_scores)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.31
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.51
@@ -394,23 +394,23 @@ class TestMatching():
         assert recommendations
         assert 3 == len(recommendations)
 
-        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
         assert not custom_loads
 
-        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
         assert conflicts
 
-        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~AreaChair_One1')
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~AreaChair_One1')
         assert ac1_conflicts
         assert len(ac1_conflicts)
         assert ac1_conflicts[0].label == 'cmu.edu'
 
-        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~Reviewer_One1')
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~Reviewer_One1')
         assert r1_conflicts
         assert len(r1_conflicts)
         assert r1_conflicts[0].label == 'mit.edu'
 
-        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = 'ac2@umass.edu')
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = 'ac2@umass.edu')
         assert ac2_conflicts
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'umass.edu'
@@ -419,21 +419,21 @@ class TestMatching():
         assert submissions
         assert 3 == len(submissions)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score')
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score')
         assert tpms_scores
         assert 15 == len(tpms_scores)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.31
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.51
@@ -510,24 +510,24 @@ class TestMatching():
         assert recommendations
         assert 3 == len(recommendations)
 
-        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Custom_Load')
+        custom_loads = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Custom_Load')
         assert not custom_loads
 
-        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict')
+        conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict')
         assert conflicts
         assert 3 == len(conflicts)
 
-        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~AreaChair_One1')
+        ac1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~AreaChair_One1')
         assert ac1_conflicts
         assert len(ac1_conflicts)
         assert ac1_conflicts[0].label == 'cmu.edu'
 
-        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = '~Reviewer_One1')
+        r1_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = '~Reviewer_One1')
         assert r1_conflicts
         assert len(r1_conflicts)
         assert r1_conflicts[0].label == 'mit.edu'
 
-        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Conflict', tail = 'ac2@umass.edu')
+        ac2_conflicts = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Conflict', tail = 'ac2@umass.edu')
         assert ac2_conflicts
         assert len(ac2_conflicts)
         assert ac2_conflicts[0].label == 'umass.edu'
@@ -536,40 +536,40 @@ class TestMatching():
         assert submissions
         assert 3 == len(submissions)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score')
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score')
         assert tpms_scores
         assert 15 == len(tpms_scores)
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[0].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.21
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[1].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.31
 
-        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
+        tpms_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/TPMS_Score', tail = 'r3@fb.com', head = submissions[2].id)
         assert tpms_scores
         assert 1 == len(tpms_scores)
         assert tpms_scores[0].weight == 0.51
 
-        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Subject_Areas_Score')
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Subject_Areas_Score')
         assert subject_areas_scores
         assert 3 == len(subject_areas_scores)
 
-        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[0].id)
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[0].id)
         assert subject_areas_scores
         assert 1 == len(subject_areas_scores)
         assert subject_areas_scores[0].weight ==  0.3333333333333333
 
-        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[1].id)
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[1].id)
         assert subject_areas_scores
         assert 1 == len(subject_areas_scores)
         assert subject_areas_scores[0].weight ==  1
 
-        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/-/Reviewing/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[2].id)
+        subject_areas_scores = client.get_edges(invitation = 'auai.org/UAI/2019/Conference/Matching/-/Subject_Areas_Score', tail = '~AreaChair_One1', head = submissions[2].id)
         assert subject_areas_scores
         assert 1 == len(subject_areas_scores)
         assert subject_areas_scores[0].weight ==  0.3333333333333333


### PR DESCRIPTION
This request is to merge into feature/edges.

This PR transfers "ownership" of the matching pipeline from the conference group to a group with id = {conference_id}/Matching (e.g. ICLR.cc/2019/Conference/Matching).

This is useful because top-level matching privileges can be given to users (e.g. Program_Chairs group) by adding them as members to ICLR.cc/2019/Conference/Matching. Prior to this, the PC group would need to be a member of the top level conference group, which can have unintended consequences. I argue that this way of doing things aligns better with our semantics and naming conventions for things.

corresponds with this PR: https://github.com/iesl/openreview/pull/1534