### PR TITLE
Updates for reviewer messaging

### DIFF
--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -410,7 +410,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
     var messageCount = localStorage.getItem('messageCount');
     if (!reviewerMessages || !messageCount) {
       $('#message-reviewers-modal').modal('hide');
-      promptError('Could not send reminder emails at this time. Please refresh the page and try again.');
+      promptError('Could not send emails at this time. Please refresh the page and try again.');
     }
     JSON.parse(reviewerMessages).forEach(postReviewerEmails);
 
@@ -418,7 +418,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
     localStorage.removeItem('messageCount');
 
     $('#message-reviewers-modal').modal('hide');
-    promptMessage('Successfully sent ' + messageCount + ' reminder emails');
+    promptMessage('Successfully sent ' + messageCount + ' emails');
   };
 
   var sortOptionHtml = Object.keys(sortOptions).map(function(option) {
@@ -432,9 +432,9 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
         '<span class="caret"></span>' +
       '</button>' +
       '<ul class="dropdown-menu" aria-labelledby="grp-msg-reviewers-btn">' +
-        '<li><a id="msg-all-reviewers">All Reviewers</a></li>' +
-        '<li><a id="msg-submitted-reviewers">Reviewers with submitted reviews</a></li>' +
-        '<li><a id="msg-unsubmitted-reviewers">Reviewers with unsubmitted reviews</a></li>' +
+        '<li><a id="msg-all-reviewers">All Reviewers of selected papers</a></li>' +
+        '<li><a id="msg-submitted-reviewers">Reviewers with submitted reviews for selected papers</a></li>' +
+        '<li><a id="msg-unsubmitted-reviewers">Reviewers with unsubmitted reviews for selected papers</a></li>' +
       '</ul>' +
     '</div>' +
     '<div class="pull-right">' +

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -433,8 +433,8 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       '</button>' +
       '<ul class="dropdown-menu" aria-labelledby="grp-msg-reviewers-btn">' +
         '<li><a id="msg-all-reviewers">All Reviewers of selected papers</a></li>' +
-        '<li><a id="msg-submitted-reviewers">Reviewers with submitted reviews for selected papers</a></li>' +
-        '<li><a id="msg-unsubmitted-reviewers">Reviewers with unsubmitted reviews for selected papers</a></li>' +
+        '<li><a id="msg-submitted-reviewers">Reviewers of selected papers with submitted reviews</a></li>' +
+        '<li><a id="msg-unsubmitted-reviewers">Reviewers of selected papers with unsubmitted reviews</a></li>' +
       '</ul>' +
     '</div>' +
     '<div class="pull-right">' +
@@ -471,7 +471,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
     }
 
-    var modalHtml = Handlebars.templates.messageReviewersModal({
+    var modalHtml = Handlebars.templates.messageReviewersModalNew({
       filter: filter,
       defaultSubject: SHORT_PHRASE + ' Reminder',
       defaultBody: defaultBody,
@@ -775,7 +775,7 @@ var registerEventHandlers = function() {
       return false;
     };
 
-    var modalHtml = Handlebars.templates.messageReviewersModal({
+    var modalHtml = Handlebars.templates.messageReviewersModalNew({
       singleRecipient: true,
       reviewerId: userId,
       forumUrl: forumUrl,
@@ -908,10 +908,10 @@ var registerEventHandlers = function() {
     return false;
   });
 
-  $('#group-container').on('click', '#select-all-papers', function(e) {
+  $('#group-container').on('change', '#select-all-papers', function(e) {
     var $superCheckBox = $(this);
-    var $allPaperCheckBoxes = $("input.select-note-reviewers");
-    var $msgReviewerButton = $("#message-reviewers-btn");
+    var $allPaperCheckBoxes = $('input.select-note-reviewers');
+    var $msgReviewerButton = $('#message-reviewers-btn');
     if ($superCheckBox[0].checked === true) {
       $allPaperCheckBoxes.prop("checked", true);
       $msgReviewerButton.attr("disabled", false);
@@ -921,10 +921,10 @@ var registerEventHandlers = function() {
     }
   });
 
-  $('#group-container').on('click', 'input.select-note-reviewers', function(e) {
-    var $allPaperCheckBoxes = $("input.select-note-reviewers");
-    var $msgReviewerButton = $("#message-reviewers-btn");
-    var $superCheckBox = $("#select-all-papers");
+  $('#group-container').on('change', 'input.select-note-reviewers', function(e) {
+    var $allPaperCheckBoxes = $('input.select-note-reviewers');
+    var $msgReviewerButton = $('#message-reviewers-btn');
+    var $superCheckBox = $('#select-all-papers');
     var checkedBoxes = $allPaperCheckBoxes.filter(function(index) {
       return $allPaperCheckBoxes[index].checked === true;
     });

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -471,7 +471,7 @@ var renderStatusTable = function(profiles, notes, completedReviews, metaReviews,
       '\n\nThank you,\n' + SHORT_PHRASE + ' Area Chair';
     }
 
-    var modalHtml = Handlebars.templates.messageReviewersModalNew({
+    var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
       filter: filter,
       defaultSubject: SHORT_PHRASE + ' Reminder',
       defaultBody: defaultBody,
@@ -775,7 +775,7 @@ var registerEventHandlers = function() {
       return false;
     };
 
-    var modalHtml = Handlebars.templates.messageReviewersModalNew({
+    var modalHtml = Handlebars.templates.messageReviewersModalFewerOptions({
       singleRecipient: true,
       reviewerId: userId,
       forumUrl: forumUrl,

--- a/openreview/conference/templates/areachairWebfield.js
+++ b/openreview/conference/templates/areachairWebfield.js
@@ -841,6 +841,12 @@ var registerEventHandlers = function() {
         signatories: [CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + nextAnonNumber]
       })
     })
+    .then(function(result) {
+      return Webfield.put('/groups/members', {
+        id: REVIEWER_GROUP,
+        members: [userToAdd]
+      })
+    })
     .then(function(results) {
       var forumUrl = 'https://openreview.net/forum?' + $.param({
         id: paperForum,
@@ -864,7 +870,7 @@ var registerEventHandlers = function() {
       var $revProgressDiv = $('#' + paperNumber + '-reviewer-progress');
       $revProgressDiv.html(Handlebars.templates.noteReviewers(reviewerSummaryMap[paperNumber]));
       updateReviewerContainer(paperNumber);
-      promptMessage('Reviewer ' + view.prettyId(userToAdd) + ' has been notified of their new assignment to paper ' + paperNumber);
+      promptMessage('Email has been sent to ' + view.prettyId(userToAdd) + ' about their new assignment to paper ' + paperNumber);
       var postData = {
         groups: [userToAdd],
         subject: SHORT_PHRASE + ": You have been assigned as a Reviewer for paper number " + paperNumber,


### PR DESCRIPTION
This is proposed change to AC console's messaging feature. We were told last week in ICLR demo that the functionality is unintuitive and we need to split it into 2 parts, one to email submitted reviewers and another to un-submitted reviewers.
The change I am proposing here is slightly from different but along the same lines.

Refer to the image below. 
![image](https://user-images.githubusercontent.com/13500158/62470155-c9ffa680-b767-11e9-9ba9-0b3c6e54c94c.png)

1. The "Message Reviewers" button has been moved to left and the "Sort By" field has been moved to the right.
2. The button "Message Reviewers" is disabled when an AC lands on this page. It has a tool-tip that says that the user needs to select papers. When one or more papers are selected, the "Message Reviewers" button is enabled.
3. ACs now a checkbox to select/deselect all papers, placed at the top of the first column of checkboxes.
4. The "Message Reviewers" button is actually a dropdown of buttons (refer to image below).
<img width="965" alt="Screen Shot 2019-08-05 at 10 07 35 AM" src="https://user-images.githubusercontent.com/13500158/62470648-e2bc8c00-b768-11e9-862f-553884c10868.png">
5. Based on the option selected, the messaging modal heading tells the user which reviewers are being emailed. 
<img width="962" alt="Screen Shot 2019-08-05 at 10 27 06 AM" src="https://user-images.githubusercontent.com/13500158/62471889-9c1c6100-b76b-11e9-85e0-635d3b87ba09.png">
6. The step-2 of messaging remains the same as earlier
<img width="959" alt="Screen Shot 2019-08-05 at 10 27 43 AM" src="https://user-images.githubusercontent.com/13500158/62471962-bfdfa700-b76b-11e9-8bd0-4fbf9ae9a316.png">

