### PR TITLE
add a non-required field to the metadata and assignment invitation sp…

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -225,7 +225,9 @@ class Matching(object):
                 },
                 'signatures': {
                     'values': [CONFERENCE_ID]},
-                'content': {}
+                'content': {
+                    'title': {'required': False, 'value': 'metadata note'}
+                }
             }
         })
 
@@ -242,7 +244,9 @@ class Matching(object):
                 'readers': {'values': [CONFERENCE_ID, PROGRAM_CHAIRS_ID]},
                 'writers': {'values': [CONFERENCE_ID]},
                 'signatures': {'values': [CONFERENCE_ID]},
-                'content': {}
+                'content': {
+                    'title': {'required': False, 'value': 'assignment note'}
+                }
             }
         })
 

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -226,7 +226,7 @@ class Matching(object):
                 'signatures': {
                     'values': [CONFERENCE_ID]},
                 'content': {
-                    'title': {'required': False, 'value': 'metadata note'}
+                    'title': {'required': False, 'value-regex': '.*'}
                 }
             }
         })
@@ -245,7 +245,7 @@ class Matching(object):
                 'writers': {'values': [CONFERENCE_ID]},
                 'signatures': {'values': [CONFERENCE_ID]},
                 'content': {
-                    'title': {'required': False, 'value': 'assignment note'}
+                    'title': {'required': False, 'value-regex': '.*'}
                 }
             }
         })


### PR DESCRIPTION
…ec, so that they can be posted.

This change fixes the failing tests in the master branch of openreview-matcher.

I'm not sure if this is the best way to do it -- Ideally we'd specify the correct fields for these invitations, but these are special cases where we may not have the right kind of values (for example, metadata notes have one field in content called `entries`, and it's a list of dict values). 

personally I think this is ok, because we'll soon stop needing metadata and assignment notes anyway...