### PR TITLE
Fix/overwritten authors

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -494,48 +494,8 @@ class Matching(object):
             for a in assignments:
                 paper_number = a[0]
                 user = a[2]
-
-                if is_area_chair:
-                    parent_label = 'Area_Chairs'
-                    individual_label = 'Area_Chair'
-                    individual_group_params = {}
-                    parent_group_params = {}
-                else:
-                    parent_label = 'Reviewers'
-                    individual_label = 'AnonReviewer'
-                    individual_group_params = {
-                        'readers': [
-                            self.conference.get_id(),
-                            self.conference.get_program_chairs_id(),
-                            self.conference.get_id() + 'Paper{0}/Area_Chairs'.format(paper_number)
-                        ],
-                        'writers': [
-                            self.conference.get_id(),
-                            self.conference.get_program_chairs_id(),
-                            self.conference.get_id() + 'Paper{0}/Area_Chairs'.format(paper_number)
-                        ]
-                    }
-                    parent_group_params = {
-                       'readers': [
-                            self.conference.get_id(),
-                            self.conference.get_program_chairs_id(),
-                            self.conference.get_id() + 'Paper{0}/Area_Chairs'.format(paper_number)
-                        ],
-                        'writers': [
-                            self.conference.get_id(),
-                            self.conference.get_program_chairs_id(),
-                            self.conference.get_id() + 'Paper{0}/Area_Chairs'.format(paper_number)
-                        ]
-                    }
-
-                new_assigned_group = openreview.tools.add_assignment(
-                    client, paper_number, self.conference.get_id(), user,
-                    parent_label = parent_label,
-                    individual_label = individual_label,
-                    individual_group_params = individual_group_params,
-                    parent_group_params = parent_group_params)
+                new_assigned_group = self.conference.set_assignment(user, paper_number, is_area_chair)
                 print(new_assigned_group)
-
 
         else:
             raise openreview.OpenReviewException('Configuration not found for ' + assingment_title)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ class TestClient():
 
     def test_get_groups(self, client):
         groups = client.get_groups()
-        assert len(groups) == 24, 'groups is empty'
+        assert len(groups) == 25, 'groups is empty'
         group_names = [g.id for g in groups]
         assert '(anonymous)' in group_names
         assert 'everyone' in group_names

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ class TestClient():
 
     def test_get_groups(self, client):
         groups = client.get_groups()
-        assert len(groups) == 25, 'groups is empty'
+        assert len(groups) == 24, 'groups is empty'
         group_names = [g.id for g in groups]
         assert '(anonymous)' in group_names
         assert 'everyone' in group_names

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -269,6 +269,50 @@ class TestWorkshop():
         assert blind_submissions[0].id == blind_submissions_3[0].id
         assert blind_submissions_3[2].readers == ['everyone']
 
+    def test_set_authors(self, client, test_client, selenium, request_page, helpers):
+
+        builder = openreview.conference.ConferenceBuilder(client)
+        assert builder, 'builder is None'
+
+        builder.set_conference_id('icaps-conference.org/ICAPS/2019/Workshop/HSDIP')
+        builder.set_conference_name('Heuristics and Search for Domain-independent Planning')
+        builder.set_conference_short_name('ICAPS HSDIP 2019')
+        builder.set_homepage_header({
+        'title': 'Heuristics and Search for Domain-independent Planning',
+        'subtitle': 'ICAPS 2019 Workshop',
+        'deadline': 'Submission Deadline: March 17, 2019 midnight AoE',
+        'date': 'July 11-15, 2019',
+        'website': 'https://icaps19.icaps-conference.org/workshops/HSDIP/index.html',
+        'location': 'Berkeley, CA, USA'
+        })
+        now = datetime.datetime.utcnow()
+        builder.set_submission_stage(double_blind = True, public = False, due_date = now + datetime.timedelta(minutes = 10))
+        builder.set_review_stage(due_date = now + datetime.timedelta(minutes = 10), release_to_authors= True, release_to_reviewers=True)
+        builder.has_area_chairs(False)
+        conference = builder.get_result()
+
+        group = client.get_group(id = conference.get_authors_id())
+        assert group
+        assert len(group.members) == 3
+
+        groups = client.get_groups(id = conference.get_authors_id(number = '.*'))
+        assert len(groups) == 3
+
+        for group in groups:
+            assert group.members
+
+        conference.set_authors()
+
+        group = client.get_group(id = conference.get_authors_id())
+        assert group
+        assert len(group.members) == 3
+
+        conference = builder.get_result()
+
+        group = client.get_group(id = conference.get_authors_id())
+        assert group
+        assert len(group.members) == 3
+
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
 
         builder = openreview.conference.ConferenceBuilder(client)

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -215,6 +215,13 @@ class TestWorkshop():
         builder.has_area_chairs(False)
         conference = builder.get_result()
 
+        group = client.get_group(id = conference.get_authors_id())
+        assert group
+        assert len(group.members) == 0
+
+        groups = client.get_groups(id = conference.get_authors_id(number = '.*'))
+        assert len(groups) == 0
+
         blind_submissions = conference.create_blind_submissions()
         assert blind_submissions
         assert len(blind_submissions) == 1


### PR DESCRIPTION
Fixes #371 

- Fix set author groups using __create_groups.
- Create paper and author groups before starting any stage. Paper group is needed to create paper related invitations.
- Remove create paper reviewers groups because it was setting the readers/nonreaders correctly. We should use set_assignment to create these groups. 
- Move de creation of the reviewers submittted group to set_assignment section. It should be created after the paper reviewer group is created. 
- Use a single function to set and deploy assignments.
- Add more tests.