### PR TITLE
Fix/improve bid webfield

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -34,6 +34,7 @@ class Conference(object):
         self.program_chairs_name = 'Program_Chairs'
         self.recommendation_name = 'Recommendation'
         self.registration_name = 'Registration'
+        self.affinity_score_name = None
         self.submission_stage = SubmissionStage()
         self.bid_stage = BidStage()
         self.expertise_selection_stage = ExpertiseSelectionStage()
@@ -285,6 +286,9 @@ class Conference(object):
 
     def get_registration_id(self):
         return self.get_invitation_id(self.registration_name)
+
+    def get_affinity_score_id(self):
+        return self.get_invitation_id(self.affinity_score_name)
 
     def get_invitation_id(self, name, number = None):
         invitation_id = self.id

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -85,12 +85,12 @@ class Conference(object):
     def __set_bid_page(self):
         bid_invitation = self.client.get_invitation(self.get_bid_id(group_id=self.get_reviewers_id()))
         if bid_invitation:
-            self.webfield_builder.set_bid_page(self, bid_invitation)
+            self.webfield_builder.set_bid_page(self, bid_invitation, self.get_reviewers_id())
 
         if self.use_area_chairs:
             bid_invitation = self.client.get_invitation(self.get_bid_id(group_id=self.get_area_chairs_id()))
             if bid_invitation:
-                self.webfield_builder.set_bid_page(self, bid_invitation)
+                self.webfield_builder.set_bid_page(self, bid_invitation, self.get_area_chairs_id())
 
     def __set_recommendation_page(self):
         recommendation_invitation = self.client.get_invitation(self.get_recommendation_id())
@@ -308,8 +308,8 @@ class Conference(object):
     def get_paper_assignment_id(self):
         return self.get_invitation_id('Reviewing/Paper_Assignment')
 
-    def get_affinity_score_id(self):
-        return self.get_invitation_id('Reviewing/Affinity_Score')
+    def get_affinity_score_id(self, group_id):
+        return self.get_invitation_id('Reviewing/Affinity_Score', prefix=group_id)
 
     def set_homepage_header(self, header):
         self.homepage_header = header
@@ -1023,8 +1023,8 @@ class ConferenceBuilder(object):
     def set_expertise_selection_stage(self, start_date = None, due_date = None):
         self.expertise_selection_stage = ExpertiseSelectionStage(start_date, due_date)
 
-    def set_bid_stage(self, start_date = None, due_date = None, request_count = 50):
-        self.bid_stage = BidStage(start_date, due_date, request_count)
+    def set_bid_stage(self, start_date = None, due_date = None, request_count = 50, use_affinity_score = False):
+        self.bid_stage = BidStage(start_date, due_date, request_count, use_affinity_score)
 
     def set_review_stage(self, start_date = None, due_date = None, name = None, allow_de_anonymization = False, public = False, release_to_authors = False, release_to_reviewers = False, email_pcs = False, additional_fields = {}):
         self.review_stage = ReviewStage(start_date, due_date, name, allow_de_anonymization, public, release_to_authors, release_to_reviewers, email_pcs, additional_fields)
@@ -1068,7 +1068,7 @@ class ConferenceBuilder(object):
         ## Create comittee groups before any other stage that requires them to create groups and/or invitations
         self.conference.set_authors()
         self.conference.set_reviewers()
-        if self.conference.use_area_chairs():
+        if self.conference.use_area_chairs:
             self.conference.set_area_chairs()
 
         home_group = groups[-1]

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -34,7 +34,6 @@ class Conference(object):
         self.program_chairs_name = 'Program_Chairs'
         self.recommendation_name = 'Recommendation'
         self.registration_name = 'Registration'
-        self.affinity_score_name = None
         self.submission_stage = SubmissionStage()
         self.bid_stage = BidStage()
         self.expertise_selection_stage = ExpertiseSelectionStage()
@@ -280,9 +279,6 @@ class Conference(object):
     def get_registration_id(self):
         return self.get_invitation_id(self.registration_name)
 
-    def get_affinity_score_id(self):
-        return self.get_invitation_id(self.affinity_score_name)
-
     def get_invitation_id(self, name, number = None):
         invitation_id = self.id
         if number:
@@ -302,8 +298,11 @@ class Conference(object):
     def get_conference_groups(self):
         return self.groups
 
-    def get_paper_assignment_id (self):
+    def get_paper_assignment_id(self):
         return self.get_invitation_id('Reviewing/Paper_Assignment')
+
+    def get_affinity_score_id(self):
+        return self.get_invitation_id('Reviewing/Affinity_Score')
 
     def set_homepage_header(self, header):
         self.homepage_header = header
@@ -786,11 +785,13 @@ class ExpertiseSelectionStage(object):
 
 class BidStage(object):
 
-    def __init__(self, start_date = None, due_date = None, request_count = 50):
+    def __init__(self, start_date = None, due_date = None, request_count = 50, use_affinity_score = False):
         self.start_date = start_date
         self.due_date = due_date
         self.name = 'Bid'
         self.request_count = request_count
+        self.use_affinity_score = use_affinity_score
+
 
 class ReviewStage(object):
 

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -308,11 +308,14 @@ class Conference(object):
     def get_conference_groups(self):
         return self.groups
 
-    def get_paper_assignment_id(self):
-        return self.get_invitation_id('Reviewing/Paper_Assignment')
+    def get_paper_assignment_id(self, group_id):
+        return self.get_invitation_id('Reviewing/Paper_Assignment', prefix=group_id)
 
     def get_affinity_score_id(self, group_id):
         return self.get_invitation_id('Reviewing/Affinity_Score', prefix=group_id)
+
+    def get_conflict_score_id(self, group_id):
+        return self.get_invitation_id('Reviewing/Conflict', prefix=group_id)
 
     def set_homepage_header(self, header):
         self.homepage_header = header

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -83,6 +83,9 @@ class Conference(object):
             return self.webfield_builder.set_expertise_selection_page(self, expertise_selection_invitation)
 
     def __set_bid_page(self):
+        """
+        Set a webfield to each available bid invitation
+        """
         bid_invitation = self.client.get_invitation(self.get_bid_id(group_id=self.get_reviewers_id()))
         if bid_invitation:
             self.webfield_builder.set_bid_page(self, bid_invitation, self.get_reviewers_id())

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1068,25 +1068,8 @@ class ConferenceBuilder(object):
         ## Create comittee groups before any other stage that requires them to create groups and/or invitations
         self.conference.set_authors()
         self.conference.set_reviewers()
-        self.conference.set_area_chairs()
-
-        if self.bid_stage:
-            self.conference.set_bid_stage(self.bid_stage)
-
-        if self.expertise_selection_stage:
-            self.conference.set_expertise_selection_stage(self.expertise_selection_stage)
-
-        if self.review_stage:
-            self.conference.set_review_stage(self.review_stage)
-
-        if self.comment_stage:
-            self.conference.set_comment_stage(self.comment_stage)
-
-        if self.meta_review_stage:
-            self.conference.set_meta_review_stage(self.meta_review_stage)
-
-        if self.decision_stage:
-            self.conference.set_decision_stage(self.decision_stage)
+        if self.conference.use_area_chairs():
+            self.conference.set_area_chairs()
 
         home_group = groups[-1]
         writable = home_group.details.get('writable') if home_group.details else True
@@ -1106,5 +1089,23 @@ class ConferenceBuilder(object):
         if self.conference.use_area_chairs:
             self.conference.set_area_chair_recruitment_groups()
         self.conference.set_reviewer_recruitment_groups()
+
+        if self.bid_stage:
+            self.conference.set_bid_stage(self.bid_stage)
+
+        if self.expertise_selection_stage:
+            self.conference.set_expertise_selection_stage(self.expertise_selection_stage)
+
+        if self.review_stage:
+            self.conference.set_review_stage(self.review_stage)
+
+        if self.comment_stage:
+            self.conference.set_comment_stage(self.comment_stage)
+
+        if self.meta_review_stage:
+            self.conference.set_meta_review_stage(self.meta_review_stage)
+
+        if self.decision_stage:
+            self.conference.set_decision_stage(self.decision_stage)
 
         return self.conference

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -119,7 +119,7 @@ class Matching(object):
 
     def _build_affinity_scores(self, affinity_score_file):
 
-        invitation = self._create_edge_invitation(self.conference.get_invitation_id('Reviewing/Affinity_Score'))
+        invitation = self._create_edge_invitation(self.conference.get_affinity_score_id())
 
         edges = []
         with open(affinity_score_file) as f:

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -18,7 +18,7 @@ class Matching(object):
             signatures = [self.conference.get_id()],
             reply = {
                 'readers': {
-                    'values': [self.conference.get_id()]
+                    'values-regex': self.conference.get_id() + '|~.*'
                 },
                 'writers': {
                     'values': [self.conference.get_id()]
@@ -74,7 +74,7 @@ class Matching(object):
                         tail = profile.id,
                         weight = 1,
                         label = ','.join(conflicts),
-                        readers = [self.conference.id],
+                        readers = [self.conference.id, profile.id], # do acs need to read all tpms scores?
                         writers = [self.conference.id],
                         signatures = [self.conference.id]
                     ))
@@ -109,7 +109,7 @@ class Matching(object):
                         head = paper_note_id,
                         tail = profile_id,
                         weight = float(score),
-                        readers = [self.conference.id],
+                        readers = [self.conference.id, profile_id], # do acs need to read all tpms scores?
                         writers = [self.conference.id],
                         signatures = [self.conference.id]
                     ))
@@ -132,7 +132,7 @@ class Matching(object):
                     head = paper_note_id,
                     tail = profile_id,
                     weight = float(score),
-                    readers = [self.conference.id],
+                    readers = [self.conference.id, profile_id], # do acs need to read all tpms scores?
                     writers = [self.conference.id],
                     signatures = [self.conference.id]
                 ))

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -72,7 +72,7 @@ class Matching(object):
         '''
         Returns a correctly formatted edge invitation ID for this Matching's match group
         '''
-        return '{}/-/{}'.format(self.match_group.id, edge_name)
+        return self.conference.get_invitation_id(edge_name, prefix=self.match_group.id)
 
     def _create_edge_invitation(self, edge_name):
         '''
@@ -370,7 +370,7 @@ class Matching(object):
         '''
         score_spec = {}
 
-        score_spec[self.conference.get_bid_id()] = {
+        score_spec[self.conference.get_bid_id(self.match_group.id)] = {
             'weight': 1,
             'default': 0,
             'translate_map' : {

--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -18,7 +18,7 @@ class Matching(object):
             signatures = [self.conference.get_id()],
             reply = {
                 'readers': {
-                    'values-regex': self.conference.get_id() + '|~.*'
+                    'values-regex': self.conference.get_id() + '|~.*|.*@.*'
                 },
                 'writers': {
                     'values': [self.conference.get_id()]

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -25,6 +25,7 @@ function getPapersSortedByAffinity(offset) {
   return Webfield.get('/edges', {
     invitation: CONFERENCE_ID + '/-/Reviewing/Affinity_Score',
     tail: user.profile.id,
+    sort: 'weight:desc',
     offset: offset,
     limit: 50
   })
@@ -39,13 +40,19 @@ function getPapersSortedByAffinity(offset) {
       ids: noteIds
     })
     .then(function(result) {
-      return result.notes;
+      //Keep affinity score order
+      var mapById = result.notes.reduce(function(mapById, note) {
+        mapById[note.id] = note;
+        return mapById;
+      }, {});
+      return noteIds.map(function(id) {
+        return mapById[id];
+      });
     })
     .then(function(notes) {
       return notes.map(function(note) {
         var edge = edgesByHead[note.id];
         //to render the edge widget correctly
-        edge.invitation = 'Affinity_Score';
         edge.signatures = [];
         note.details = {
           edges: [edge]
@@ -64,24 +71,6 @@ function getPapersByBids(bids, bidsByNote) {
   .then(function(result) {
     return addEdgesToNotes(result.notes, bidsByNote);
   });
-}
-
-function getBidCounts(edgesMap) {
-  var containers = {
-    'Very High': 0,
-    'High': 0,
-    'Neutral': 0,
-    'Low': 0,
-    'Very Low': 0
-  };
-  var totalCount = 0;
-
-  for (key in edgesMap) {
-    var label = edgesMap[key].label;
-    containers[label] += 1;
-  }
-
-  return containers;
 }
 
 // Perform all the required API calls

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -6,10 +6,10 @@ var CONFERENCE_ID = '';
 var HEADER = {};
 var SHORT_PHRASE = '';
 var BLIND_SUBMISSION_ID = '';
-var SUBMISSION_ID = '';
 var BID_ID = '';
 var SUBJECT_AREAS = '';
 var AFFINITY_SCORE_ID = '';
+var CONFLICT_SCORE_ID = '';
 var noteCount = 0;
 
 // Main is the entry point to the webfield code and runs everything
@@ -95,7 +95,7 @@ function load() {
   var sortedNotesP = getPapersSortedByAffinity(0);
 
   var conflictIdsP = Webfield.getAll('/edges', {
-    invitation: CONFERENCE_ID + '/-/Reviewing/Conflict',
+    invitation: CONFLICT_SCORE_ID,
     tail: user.profile.id
   })
   .then(function(edges) {

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -26,7 +26,7 @@ function main() {
 function getPapersSortedByAffinity(offset) {
   if (AFFINITY_SCORE_ID) {
     return Webfield.get('/edges', {
-      invitation: CONFERENCE_ID + '/-/Reviewing/Affinity_Score',
+      invitation: AFFINITY_SCORE_ID,
       tail: user.profile.id,
       sort: 'weight:desc',
       offset: offset,

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -29,7 +29,9 @@ function getPapersSortedByAffinity(offset) {
     limit: 50
   })
   .then(function(result) {
+    var edgesByHead = {};
     var noteIds = result.edges.map(function(edge) {
+      edgesByHead[edge.head] = edge;
       return edge.head;
     });
 
@@ -38,6 +40,18 @@ function getPapersSortedByAffinity(offset) {
     })
     .then(function(result) {
       return result.notes;
+    })
+    .then(function(notes) {
+      return notes.map(function(note) {
+        var edge = edgesByHead[note.id];
+        //to render the edge widget correctly
+        edge.invitation = 'Affinity_Score';
+        edge.signatures = [];
+        note.details = {
+          edges: [edge]
+        }
+        return note;
+      })
     })
   });
 }
@@ -289,16 +303,15 @@ function prepareNotes(notes, conflictIds, edgesMap) {
 
 function addEdgesToNotes(validNotes, edgesMap) {
   for (var i = 0; i < validNotes.length; i++) {
-    var noteId = validNotes[i].id;
-    if (edgesMap.hasOwnProperty(noteId)) {
-      validNotes[i].details = {
-        edges: [edgesMap[noteId]]
-      };
-    } else {
-      validNotes[i].details = {
+    var note = validNotes[i];
+    if (!_.has(note, 'details.edges')) {
+      note.details = {
         edges: []
-      };
+      }
     }
+    if (edgesMap.hasOwnProperty(note.id)) {
+      note.details.edges.push(edgesMap[note.id]);
+    };
   }
   return validNotes;
 }

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -10,6 +10,7 @@ var SUBMISSION_ID = '';
 var BID_ID = '';
 var SUBJECT_AREAS = '';
 var AFFINITY_SCORE_ID = '';
+var noteCount = 0;
 
 // Main is the entry point to the webfield code and runs everything
 function main() {
@@ -32,6 +33,7 @@ function getPapersSortedByAffinity(offset) {
       limit: 50
     })
     .then(function(result) {
+      noteCount = result.count;
       var edgesByHead = {};
       var noteIds = result.edges.map(function(edge) {
         edgesByHead[edge.head] = edge;
@@ -70,6 +72,7 @@ function getPapersSortedByAffinity(offset) {
       limit: 50
     })
     .then(function(result) {
+      noteCount = result.count;
       return result.notes;
     })
   }
@@ -256,7 +259,7 @@ function renderContent(notes, conflictIds, bidEdges) {
       },
       displayOptions: paperDisplayOptions,
       autoLoad: false,
-      noteCount: 1600,
+      noteCount: noteCount,
       pageSize: 50,
       onPageClick: function(offset) {
         return getPapersSortedByAffinity(offset)

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -47,7 +47,7 @@ function getPapersSortedByAffinity(offset) {
         var notesById = _.keyBy(result.notes, function(note) {
           return note.id;
         });
-        notes = noteIds.map(function(id) {
+        return noteIds.map(function(id) {
           var note = notesById[id];
           var edge = edgesByHead[id];
           //to render the edge widget correctly
@@ -57,7 +57,6 @@ function getPapersSortedByAffinity(offset) {
           }
           return note;
         });
-        return notes;
       })
     });
   } else {

--- a/openreview/conference/templates/bidWebfield.js
+++ b/openreview/conference/templates/bidWebfield.js
@@ -54,7 +54,6 @@ function getPapersByBids(bids, bidsByNote) {
 
 function getBidCounts(edgesMap) {
   var containers = {
-    'No Bid': 0,
     'Very High': 0,
     'High': 0,
     'Neutral': 0,
@@ -70,9 +69,6 @@ function getBidCounts(edgesMap) {
 
   return containers;
 }
-
-
-
 
 // Perform all the required API calls
 function load() {
@@ -160,64 +156,13 @@ function renderContent(notes, conflictIds, bidEdges) {
       delete bidsByNote[edge.head];
       bidsById[edge.label] = bidsById[edge.label].filter(function(e) { return edge.id != e.id; });
     } else {
+      var previousEdge = bidsByNote[edge.head];
       bidsByNote[edge.head] = edge;
       bidsById[edge.label].push(edge);
+      if (previousEdge) {
+        bidsById[previousEdge.label] = bidsById[previousEdge.label].filter(function(e) { return previousEdge.id != e.id; });
+      }
     }
-
-    // var updatedNote = _.find(validNotes, ['id', edgeObj.head]);
-    // if (!updatedNote) {
-    //   return;
-    // }
-    // var prevEdgeIndex = _.findIndex(updatedNote.details.edges, ['invitation', BID_ID]);
-    // var prevVal = prevEdgeIndex !== -1 ?
-    //   updatedNote.details.edges[prevEdgeIndex].label :
-    //   'No Bid';
-
-    // if (edgeObj.ddate) {
-    //   edgeObj.label = 'No Bid';
-    // }
-    // updatedNote.details.edges[prevEdgeIndex] = edgeObj;
-
-    // var labelToContainerId = {
-    //   'Very High': 'veryHigh',
-    //   'High': 'high',
-    //   'Neutral': 'neutral',
-    //   'Low': 'low',
-    //   'Very Low': 'veryLow',
-    //   'No Bid': 'noBid'
-    // };
-
-    // var previousNoteList = binnedNotes[labelToContainerId[prevVal]];
-    // var currentNoteList = binnedNotes[labelToContainerId[edgeObj.label]];
-
-    // var currentIndex = _.findIndex(previousNoteList, ['id', edgeObj.head]);
-    // if (currentIndex !== -1) {
-    //   var currentNote = previousNoteList[currentIndex];
-    //   currentNote.details.edges = [edgeObj]; // Assumes notes will have only 1 type of edge
-    //   previousNoteList.splice(currentIndex, 1);
-    //   currentNoteList.push(currentNote);
-    // } else {
-    //   console.warn('Note not found!');
-    // }
-
-    // If the current tab is not the All Papers tab remove the note from the DOM and
-    // update the state of edge widget in the All Papers tab
-    // if (activeTab) {
-    //   var $elem = $(e.target).closest('.note');
-    //   $elem.fadeOut('normal', function() {
-    //     $elem.remove();
-
-    //     var $container = $('#' + labelToContainerId[prevVal] + ' .submissions-list');
-    //     if (!$container.children().length) {
-    //       $container.append('<li><p class="empty-message">No papers to display at this time</p></li>');
-    //     }
-    //   });
-
-    //   var $noteToChange = $('#allPapers .submissions-list .note[data-id="' + updatedNote.id + '"]');
-    //   $noteToChange.find('label[data-value="' + prevVal + '"]').removeClass('active')
-    //     .children('input').prop('checked', false);
-    //   $noteToChange.find('label[data-value="' + edgeObj.label + '"]').button('toggle');
-    // }
 
      updateCounts();
   });
@@ -234,12 +179,6 @@ function renderContent(notes, conflictIds, bidEdges) {
         heading: 'All Papers  <span class="glyphicon glyphicon-search"></span>',
         id: 'allPapers',
         content: null
-      },
-      {
-        heading: 'No Bid',
-        headingCount: 0,
-        id: 'noBid',
-        content: loadingContent
       },
       {
         heading: 'Very High',
@@ -322,7 +261,7 @@ function renderContent(notes, conflictIds, bidEdges) {
 
     var totalCount = 0;
 
-    for(var i = 2; i < sections.length; i++) {
+    for(var i = 1; i < sections.length; i++) {
       var $tab = $('ul.nav-tabs li a[href="#' + sections[i].id + '"]');
       var numPapers = bidsById[sections[i].heading].length;
 
@@ -331,9 +270,7 @@ function renderContent(notes, conflictIds, bidEdges) {
         $tab.append('<span class="badge">' + numPapers + '</span>');
       }
 
-      if (sections[i].heading != 'noBid') {
-        totalCount += numPapers;
-      }
+      totalCount += numPapers;
     };
 
     $('#bidcount').remove();

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -145,6 +145,7 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
             content = content.replace("var BID_ID = '';", "var BID_ID = '" + invitation.id + "';")
             content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.submission_stage.subject_areas) + ";")
+            content = content.replace("var CONFLICT_SCORE_ID = '';", "var CONFLICT_SCORE_ID = '" + conference.get_conflict_score_id(group_id) + "';")
 
             if conference.bid_stage.use_affinity_score:
                 content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_affinity_score_id(group_id) + "';")

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -143,7 +143,7 @@ class WebfieldBuilder(object):
             content = content.replace("var HEADER = {};", "var HEADER = " + json.dumps(header) + ";")
             content = content.replace("var BLIND_SUBMISSION_ID = '';", "var BLIND_SUBMISSION_ID = '" + conference.get_blind_submission_id() + "';")
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
-            content = content.replace("var BID_ID = '';", "var BID_ID = '" + conference.get_bid_id() + "';")
+            content = content.replace("var BID_ID = '';", "var BID_ID = '" + invitation.id + "';")
             content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.submission_stage.subject_areas) + ";")
 
             if conference.bid_stage.use_affinity_score:

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -123,24 +123,12 @@ class WebfieldBuilder(object):
             'title': conference.get_short_name() + ' Bidding Console',
             'instructions': '<p class="dark">Please indicate your level of interest in reviewing \
                 the submitted papers below, on a scale from "Very Low" to "Very High".</p>\
-                <p class="dark"><strong>Please note:</strong></p>\
-                <ul>\
-                    <li>Please update your Conflict of Interest details on your profile page, specifically "Emails", "Education and Career History" & "Advisors and Other Relations" fields.</li>\
-                    <li>The default bid on each paper is \"No Bid\".</li>\
-                </ul>\
                 <p class="dark"><strong>A few tips:</strong></p>\
                 <ul>\
                     <li>Please bid on as many papers as possible to ensure that your preferences are taken into account.</li>\
-                    <li>For the best bidding experience, <strong>it is recommended that you filter papers by Subject Area</strong> and search for key phrases in paper metadata using the search form.</li>\
+                    <li>Papers are filtered out by conflict of interest and sorted by your affinity score. Use the search texbox to filter them by subject areas</li>\
                 </ul>\
-                <p class="dark"><strong>Bid Score Value Mapping:</strong></p>\
-                <ul>\
-                    <li>Very high (+1.0)</li>\
-                    <li>High (+0.5)</li>\
-                    <li>Neutral, No Bid (0.0)</li>\
-                    <li>Low (-0.5) </li>\
-                    <li>Very Low (-1.0)</li>\
-                </ul><br>'
+                <br>'
         }
 
         header = self.__build_options(default_header, conference.get_bidpage_header())
@@ -153,6 +141,7 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
             content = content.replace("var BID_ID = '';", "var BID_ID = '" + conference.get_bid_id() + "';")
             content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.submission_stage.subject_areas) + ";")
+            content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_bid_id() + "';")
 
             invitation.web = content
             return self.client.post_invitation(invitation)

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -117,7 +117,7 @@ class WebfieldBuilder(object):
             invitation.web = content
             return self.client.post_invitation(invitation)
 
-    def set_bid_page(self, conference, invitation):
+    def set_bid_page(self, conference, invitation, group_id):
 
         sorted_tip = ''
         if conference.bid_stage.use_affinity_score:
@@ -147,7 +147,7 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.submission_stage.subject_areas) + ";")
 
             if conference.bid_stage.use_affinity_score:
-                content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_affinity_score_id() + "';")
+                content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_affinity_score_id(group_id) + "';")
 
             invitation.web = content
             return self.client.post_invitation(invitation)

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -119,6 +119,10 @@ class WebfieldBuilder(object):
 
     def set_bid_page(self, conference, invitation):
 
+        sorted_tip = ''
+        if conference.bid_stage.use_affinity_score:
+            sorted_tip = 'and sorted by your affinity score'
+
         default_header = {
             'title': conference.get_short_name() + ' Bidding Console',
             'instructions': '<p class="dark">Please indicate your level of interest in reviewing \
@@ -126,9 +130,9 @@ class WebfieldBuilder(object):
                 <p class="dark"><strong>A few tips:</strong></p>\
                 <ul>\
                     <li>Please bid on as many papers as possible to ensure that your preferences are taken into account.</li>\
-                    <li>Papers are filtered out by conflict of interest and sorted by your affinity score. Use the search texbox to filter them by subject areas</li>\
+                    <li>Papers are filtered out by conflict of interest {sorted_tip}. Use the search texbox to filter them by subject areas.</li>\
                 </ul>\
-                <br>'
+                <br>'.format(sorted_tip = sorted_tip)
         }
 
         header = self.__build_options(default_header, conference.get_bidpage_header())
@@ -141,7 +145,9 @@ class WebfieldBuilder(object):
             content = content.replace("var SUBMISSION_ID = '';", "var SUBMISSION_ID = '" + conference.get_submission_id() + "';")
             content = content.replace("var BID_ID = '';", "var BID_ID = '" + conference.get_bid_id() + "';")
             content = content.replace("var SUBJECT_AREAS = '';", "var SUBJECT_AREAS = " + str(conference.submission_stage.subject_areas) + ";")
-            content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_bid_id() + "';")
+
+            if conference.bid_stage.use_affinity_score:
+                content = content.replace("var AFFINITY_SCORE_ID = '';", "var AFFINITY_SCORE_ID = '" + conference.get_affinity_score_id() + "';")
 
             invitation.web = content
             return self.client.post_invitation(invitation)

--- a/openreview/conference/webfield.py
+++ b/openreview/conference/webfield.py
@@ -121,7 +121,7 @@ class WebfieldBuilder(object):
 
         sorted_tip = ''
         if conference.bid_stage.use_affinity_score:
-            sorted_tip = 'and sorted by your affinity score'
+            sorted_tip = ' and sorted by your affinity score'
 
         default_header = {
             'title': conference.get_short_name() + ' Bidding Console',
@@ -130,7 +130,7 @@ class WebfieldBuilder(object):
                 <p class="dark"><strong>A few tips:</strong></p>\
                 <ul>\
                     <li>Please bid on as many papers as possible to ensure that your preferences are taken into account.</li>\
-                    <li>Papers are filtered out by conflict of interest {sorted_tip}. Use the search texbox to filter them by subject areas.</li>\
+                    <li>Papers are filtered out by conflict of interest{sorted_tip}. Use the search texbox to filter them by subject areas.</li>\
                 </ul>\
                 <br>'.format(sorted_tip = sorted_tip)
         }

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -780,7 +780,7 @@ class TestDoubleBlindConference():
         conference.set_area_chairs(emails = ['ac@mail.com'])
         conference.set_reviewers(emails = ['reviewer2@mail.com'])
 
-        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/-/Bid", reviewer_client.token)
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token)
         tabs = selenium.find_element_by_class_name('tabs-container')
         assert tabs
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -818,7 +818,7 @@ class TestDoubleBlindConference():
         notes = client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
         submission = notes[0]
 
-        with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w', newline='') as file_handle:
+        with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w') as file_handle:
             writer = csv.writer(file_handle)
             writer.writerow([submission.id, '~Reviewer_DoubleBlind1', '0.9'])
 

--- a/tests/test_double_blind_conference.py
+++ b/tests/test_double_blind_conference.py
@@ -6,6 +6,7 @@ import datetime
 import time
 import os
 import re
+import csv
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -769,27 +770,10 @@ class TestDoubleBlindConference():
         reply_row = selenium.find_element_by_class_name('reply_row')
         assert len(reply_row.find_elements_by_class_name('btn')) == 0
 
-    def test_open_bids(self, client, test_client, selenium, request_page):
+    def test_open_bids(self, client, test_client, selenium, request_page, helpers):
 
-        reviewer_client = openreview.Client(baseurl = 'http://localhost:3000')
-        assert reviewer_client is not None, "Client is none"
-        res = reviewer_client.register_user(email = 'reviewer2@mail.com', first = 'Reviewer', last = 'DoubleBlind', password = '1234')
-        assert res, "Res i none"
-        res = reviewer_client.activate_user('reviewer2@mail.com', {
-            'names': [
-                    {
-                        'first': 'Reviewer',
-                        'last': 'DoubleBlind',
-                        'username': '~Reviewer_DoubleBlind1'
-                    }
-                ],
-            'emails': ['reviewer2@mail.com'],
-            'preferredEmail': 'reviewer2@mail.com'
-            })
-        assert res, "Res i none"
-        group = reviewer_client.get_group(id = 'reviewer2@mail.com')
-        assert group
-        assert group.members == ['~Reviewer_DoubleBlind1']
+        reviewer_client = helpers.create_user('reviewer2@mail.com', 'Reviewer', 'DoubleBlind')
+        ac_client = helpers.create_user('ac@mail.com', 'AreaChair', 'DoubleBlind')
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'
@@ -807,6 +791,50 @@ class TestDoubleBlindConference():
         request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token)
         tabs = selenium.find_element_by_class_name('tabs-container')
         assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert len(notes) == 3
+
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert len(notes) == 3
+
+        builder.set_bid_stage(due_date =  now + datetime.timedelta(minutes = 10), request_count = 50, use_affinity_score = True)
+        conference = builder.get_result()
+
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert not notes
+
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert not notes
+
+        notes = client.get_notes(invitation='AKBC.ws/2019/Conference/-/Blind_Submission')
+        submission = notes[0]
+
+        with open(os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'), 'w', newline='') as file_handle:
+            writer = csv.writer(file_handle)
+            writer.writerow([submission.id, '~Reviewer_DoubleBlind1', '0.9'])
+
+        conference.setup_matching(affinity_score_file=os.path.join(os.path.dirname(__file__), 'data/reviewer_affinity_scores.csv'))
+
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Reviewers/-/Bid", reviewer_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert len(notes) == 1
+
+        request_page(selenium, "http://localhost:3000/invitation?id=AKBC.ws/2019/Conference/Area_Chairs/-/Bid", ac_client.token)
+        tabs = selenium.find_element_by_class_name('tabs-container')
+        assert tabs
+        notes = selenium.find_elements_by_class_name('note')
+        assert not notes
 
     def test_open_reviews(self, client, test_client, selenium, request_page, helpers):
 
@@ -961,27 +989,10 @@ class TestDoubleBlindConference():
         assert 'ac@mail.com' in recipients
         assert 'reviewer2@mail.com' in recipients
 
-    def test_open_meta_reviews(self, client, test_client, selenium, request_page):
+    def test_open_meta_reviews(self, client, test_client, selenium, request_page, helpers):
 
-        ac_client = openreview.Client(baseurl = 'http://localhost:3000')
+        ac_client = openreview.Client(baseurl = 'http://localhost:3000', username='ac@mail.com', password='1234')
         assert ac_client is not None, "Client is none"
-        res = ac_client.register_user(email = 'ac@mail.com', first = 'AreaChair', last = 'DoubleBlind', password = '1234')
-        assert res, "Res i none"
-        res = ac_client.activate_user('ac@mail.com', {
-            'names': [
-                    {
-                        'first': 'AreaChair',
-                        'last': 'DoubleBlind',
-                        'username': '~AreaChair_DoubleBlind1'
-                    }
-                ],
-            'emails': ['ac@mail.com'],
-            'preferredEmail': 'ac@mail.com'
-            })
-        assert res, "Res i none"
-        group = ac_client.get_group(id = 'ac@mail.com')
-        assert group
-        assert group.members == ['~AreaChair_DoubleBlind1']
 
         builder = openreview.conference.ConferenceBuilder(client)
         assert builder, 'builder is None'

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -126,7 +126,7 @@ class TestMatching():
         conference.set_authors()
 
         ac1_client = helpers.create_user('ac1@cmu.edu', 'AreaChair', 'One')
-        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_area_chairs_id()),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
@@ -134,7 +134,7 @@ class TestMatching():
             tail = '~AreaChair_One1',
             label = 'High'
         ))
-        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_area_chairs_id()),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
@@ -142,7 +142,7 @@ class TestMatching():
             tail = '~AreaChair_One1',
             label = 'Low'
         ))
-        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        ac1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_area_chairs_id()),
             readers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~AreaChair_One1'],
             signatures = ['~AreaChair_One1'],
@@ -152,7 +152,7 @@ class TestMatching():
         ))
 
         r1_client = helpers.create_user('r1@mit.edu', 'Reviewer', 'One')
-        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_reviewers_id()),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
@@ -160,7 +160,7 @@ class TestMatching():
             tail = '~Reviewer_One1',
             label = 'Neutral'
         ))
-        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_reviewers_id()),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
@@ -168,7 +168,7 @@ class TestMatching():
             tail = '~Reviewer_One1',
             label = 'Very High'
         ))
-        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(),
+        r1_client.post_edge(openreview.Edge(invitation = conference.get_bid_id(conference.get_reviewers_id()),
             readers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             writers = ['auai.org/UAI/2019/Conference', '~Reviewer_One1'],
             signatures = ['~Reviewer_One1'],
@@ -196,9 +196,13 @@ class TestMatching():
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Aggregate_Score')
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Paper_Assignment')
 
-        bids = client.get_edges(invitation = conference.get_bid_id())
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_area_chairs_id()))
         assert bids
-        assert 6 == len(bids)
+        assert 3 == len(bids)
+
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_reviewers_id()))
+        assert bids
+        assert 3 == len(bids)
 
         reviewer_custom_loads = client.get_edges(
             invitation='auai.org/UAI/2019/Conference/Program_Committee/-/Reviewing/Custom_Load')
@@ -301,9 +305,13 @@ class TestMatching():
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Paper_Assignment')
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/TPMS_Score')
 
-        bids = client.get_edges(invitation = conference.get_bid_id())
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_area_chairs_id()))
         assert bids
-        assert 6 == len(bids)
+        assert 3 == len(bids)
+
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_reviewers_id()))
+        assert bids
+        assert 3 == len(bids)
 
         reviewer_custom_loads = client.get_edges(
             invitation='auai.org/UAI/2019/Conference/Program_Committee/-/Reviewing/Custom_Load')
@@ -464,9 +472,13 @@ class TestMatching():
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Custom_Load')
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Conflict')
 
-        bids = client.get_edges(invitation = conference.get_bid_id())
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_area_chairs_id()))
         assert bids
-        assert 6 == len(bids)
+        assert 3 == len(bids)
+
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_reviewers_id()))
+        assert bids
+        assert 3 == len(bids)
 
         recommendations = client.get_edges(invitation = conference.get_recommendation_id())
         assert recommendations
@@ -618,9 +630,13 @@ class TestMatching():
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Custom_Load')
         assert client.get_invitation(id='auai.org/UAI/2019/Conference/Senior_Program_Committee/-/Reviewing/Conflict')
 
-        bids = client.get_edges(invitation = conference.get_bid_id())
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_area_chairs_id()))
         assert bids
-        assert 6 == len(bids)
+        assert 3 == len(bids)
+
+        bids = client.get_edges(invitation = conference.get_bid_id(conference.get_reviewers_id()))
+        assert bids
+        assert 3 == len(bids)
 
         recommendations = client.get_edges(invitation = conference.get_recommendation_id())
         assert recommendations


### PR DESCRIPTION
- Create one bid invitation per matching group: Reviewers, Area Chairs.
- Refactor the bid webfield to sort the All Papers tab by affinity score. This sorting can be optional, it the venue doesn't request the affinity scores then papers without sorting are rendered.
- If papers are sorting by score, the score is being displayed below each note panel.
- Papers are also filtered by conflicts edges (includes authored papers). If the venue doesn't have conflicts edges previously created then it doesn't apply any filter.
- No Bid was removed.
- Each bid type tab is rendered when the user clicks on it. It loads all the information from the server. It doesn't paginate the result of each tab, I assume there is no going to be more than 1k bids with the same type. But if that happens we can implement pagination here too.
- Header wording was changes, @mspector please review. 

This new UI should support unlimited amount of papers to review. 

<img width="1344" alt="Screen Shot 2019-08-07 at 4 38 02 PM" src="https://user-images.githubusercontent.com/545506/62803796-6a7ffe80-bab9-11e9-9fe3-812b03ec8470.png">

<img width="1012" alt="Screen Shot 2019-08-07 at 4 38 34 PM" src="https://user-images.githubusercontent.com/545506/62803806-723fa300-bab9-11e9-8a1c-a0e9e570a8fa.png">
