### PR TITLE
Removed unnecessary call to set_area_chairs from matching.py

### DIFF
--- a/openreview/conference/matching.py
+++ b/openreview/conference/matching.py
@@ -479,8 +479,6 @@ class Matching(object):
         # Get the configuration note to check the group to assign
         client = self.conference.client
         notes = client.get_notes(invitation = self.conference.get_id() + '/-/Assignment_Configuration', content = { 'title': assingment_title })
-        if self.conference.use_area_chairs:
-            self.conference.set_area_chairs(enable_reviewer_reassignment = True)
 
         if notes:
             configuration_note = notes[0]


### PR DESCRIPTION
We were earlier calling set_area_chairs to enable reviewer reassignment at the time of deployment. This call is not necessary now as we are enabling reviewer reassignment in conference.set_assignments.