### PR TITLE
Do not create Blind submissions if the submission stage has a due date in the future

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import time
 import re
+import datetime
 from .. import openreview
 from .. import tools
 from . import webfield
@@ -373,6 +374,9 @@ class Conference(object):
 
         if not self.submission_stage.double_blind:
             raise openreview.OpenReviewException('Conference is not double blind')
+
+        if self.submission_stage.due_date and (tools.datetime_millis(self.submission_stage.due_date) > tools.datetime_millis(datetime.datetime.utcnow())):
+            raise openreview.OpenReviewException('Submission invitation is still due. Aborted blind note creation!')
 
         submissions_by_original = { note.original: note for note in self.get_submissions() }
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='openreview-py',
-      version='0.9.25',
+      version='0.9.26',
       description='OpenReview client library',
       url='https://github.com/iesl/openreview-py',
       author='Michael Spector, Melisa Bok, Pam Mander, Mohit Uniyal',

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -105,6 +105,12 @@ class TestBuilder():
         assert original_notes
         assert len(original_notes) == 1
 
+        with pytest.raises(openreview.OpenReviewException, match=r'.*Submission invitation is still due. Aborted blind note creation.*'):
+            conference.create_blind_submissions()
+
+        builder.set_submission_stage(double_blind = True, public = False, due_date = now)
+        conference = builder.get_result()
+
         blind_submissions = conference.create_blind_submissions()
         assert blind_submissions
         assert len(blind_submissions) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,7 +153,7 @@ class TestClient():
 
     def test_get_invitations_by_invitee(self, client):
         invitations = client.get_invitations(invitee = '~', pastdue = False)
-        assert len(invitations) == 1
+        assert len(invitations) == 0
 
         invitations = client.get_invitations(invitee = True, duedate = True, details = 'replytoNote,repliedNotes')
         assert len(invitations) == 0

--- a/tests/test_comment_notifications.py
+++ b/tests/test_comment_notifications.py
@@ -371,6 +371,14 @@ class TestCommentNotification():
         assert logs
         assert logs[0]['status'] == 'ok'
 
+        builder.set_submission_stage(double_blind = True, due_date = now, subject_areas= [
+            "Algorithms: Approximate Inference",
+            "Algorithms: Belief Propagation",
+            "Algorithms: Distributed and Parallel",
+            "Algorithms: Exact Inference",
+        ])
+        conference = builder.get_result()
+
         conference.close_submissions()
         blinded_notes = conference.create_blind_submissions()
         paper_note = blinded_notes[0]

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -122,6 +122,13 @@ class TestMatching():
         note_3 = test_client.post_note(note_3)
 
         ## Create blind submissions
+        builder.set_submission_stage(due_date = now, double_blind= True, subject_areas=[
+            "Algorithms: Approximate Inference",
+            "Algorithms: Belief Propagation",
+            "Algorithms: Distributed and Parallel",
+            "Algorithms: Exact Inference",
+        ])
+        conference = builder.get_result()
         blinded_notes = conference.create_blind_submissions()
         conference.set_authors()
 

--- a/tests/test_workshop.py
+++ b/tests/test_workshop.py
@@ -222,6 +222,9 @@ class TestWorkshop():
         groups = client.get_groups(id = conference.get_authors_id(number = '.*'))
         assert len(groups) == 0
 
+        builder.set_submission_stage(double_blind = True, public = False, due_date = now)
+        conference = builder.get_result()
+
         blind_submissions = conference.create_blind_submissions()
         assert blind_submissions
         assert len(blind_submissions) == 1
@@ -269,6 +272,9 @@ class TestWorkshop():
         url = client.put_pdf(os.path.join(os.path.dirname(__file__), 'data/paper.pdf'))
         note.content['pdf'] = url
         client.post_note(note)
+
+        builder.set_submission_stage(double_blind = True, public = True, due_date = now)
+        conference = builder.get_result()
 
         blind_submissions_3 = conference.create_blind_submissions()
         assert blind_submissions_3


### PR DESCRIPTION
Throw an OpenReview exception if blind notes creation is attempted while submission invitation is still not past due date.