### PR TITLE
added set/get year methods to conference class

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -193,6 +193,12 @@ class Conference(object):
     def get_short_name(self):
         return self.short_name
 
+    def set_year(self, year):
+        self.year = year
+
+    def get_year(self, year):
+        return self.year
+
     def set_reviewers_name(self, name):
         self.reviewers_name = name
 


### PR DESCRIPTION
this is needed as set_year is called by builder. set_conference_year  while creating _bibtex automatically.