### PR TITLE
Feature/withdraw invitation

### DIFF
--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -835,8 +835,7 @@ class SubmissionStage(object):
             name = 'Blind_' + name
         return conference.get_invitation_id(name)
 
-    def get_withdrawn_submission_id(self, conference):
-        name = 'Withdrawn_Submission'
+    def get_withdrawn_submission_id(self, conference, name = 'Withdrawn_Submission'):
         return conference.get_invitation_id(name)
 
 class ExpertiseSelectionStage(object):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -371,12 +371,7 @@ class Conference(object):
         if not self.submission_stage.allow_withdraw:
             raise openreview.OpenReviewException('Conference does not allow withdraw invitations')
 
-        if not self.submission_stage.double_blind:
-            raise openreview.OpenReviewException(
-                'Withdraw invitations are currently only supported for double blind conferences')
-
-        withdraw_invitations = self.invitation_builder.set_withdraw_invitation(
-            self, self.get_submissions())
+        withdraw_invitations = self.invitation_builder.set_withdraw_invitation(self)
 
 
     def create_blind_submissions(self):

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -1077,6 +1077,7 @@ class ConferenceBuilder(object):
             public=False,
             double_blind=False,
             allow_withdraw=False,
+            reveal_authors_on_withdraw=False,
             additional_fields={},
             remove_fields=[],
             subject_areas=[]
@@ -1089,6 +1090,7 @@ class ConferenceBuilder(object):
             public,
             double_blind,
             allow_withdraw,
+            reveal_authors_on_withdraw,
             additional_fields,
             remove_fields,
             subject_areas

--- a/openreview/conference/builder.py
+++ b/openreview/conference/builder.py
@@ -720,7 +720,7 @@ class SubmissionStage(object):
             public=False,
             double_blind=False,
             allow_withdraw=False,
-            reveal_on_withdraw=False,
+            reveal_authors_on_withdraw=False,
             additional_fields={},
             remove_fields=[],
             subject_areas=[]
@@ -732,6 +732,7 @@ class SubmissionStage(object):
         self.public = public
         self.double_blind = double_blind
         self.allow_withdraw = allow_withdraw
+        self.reveal_authors_on_withdraw = reveal_authors_on_withdraw
         self.additional_fields = additional_fields
         self.remove_fields = remove_fields
         self.subject_areas = subject_areas
@@ -777,7 +778,7 @@ class SubmissionStage(object):
         return conference.get_invitation_id(name)
 
     def get_withdrawn_submission_id(self, conference):
-        name = 'Withdrawn {}'.format(self.name)
+        name = 'Withdrawn_Submission'
         return conference.get_invitation_id(name)
 
 class BidStage(object):
@@ -1017,7 +1018,7 @@ class ConferenceBuilder(object):
             due_date,
             public,
             double_blind,
-            allow_withdraw
+            allow_withdraw,
             additional_fields,
             remove_fields,
             subject_areas

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -71,9 +71,7 @@ def get_conference(client, request_form_id):
     submission_additional_options = note.content.get('Additional Submission Options', {})
     if isinstance(submission_additional_options, str):
         submission_additional_options = json.loads(submission_additional_options.strip())
-    print ('yahoo!!!')
-    print (submission_additional_options)
-    builder.set_submission_stage(double_blind = double_blind, public = public, start_date = submission_start_date, due_date = submission_due_date, additional_fields = submission_additional_options, allow_withdraw = True)
+    builder.set_submission_stage(double_blind = double_blind, public = public, start_date = submission_start_date, due_date = submission_due_date, additional_fields = submission_additional_options, allow_withdraw = True, reveal_authors_on_withdraw = True)
 
     paper_matching_options = note.content.get('Paper Matching', [])
     if 'OpenReview Affinity' in paper_matching_options:

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -70,7 +70,8 @@ def get_conference(client, request_form_id):
     submission_additional_options = note.content.get('Additional Submission Options', {})
     if isinstance(submission_additional_options, str):
         submission_additional_options = json.loads(submission_additional_options.strip())
-
+    print ('yahoo!!!')
+    print (submission_additional_options)
     builder.set_submission_stage(double_blind = double_blind, public = public, start_date = submission_start_date, due_date = submission_due_date, additional_fields = submission_additional_options, allow_withdraw = True)
 
     conference = builder.get_result()

--- a/openreview/conference/helpers.py
+++ b/openreview/conference/helpers.py
@@ -71,7 +71,7 @@ def get_conference(client, request_form_id):
     if isinstance(submission_additional_options, str):
         submission_additional_options = json.loads(submission_additional_options.strip())
 
-    builder.set_submission_stage(double_blind = double_blind, public = public, start_date = submission_start_date, due_date = submission_due_date, additional_fields = submission_additional_options)
+    builder.set_submission_stage(double_blind = double_blind, public = public, start_date = submission_start_date, due_date = submission_due_date, additional_fields = submission_additional_options, allow_withdraw = True)
 
     conference = builder.get_result()
     conference.set_program_chairs(emails = note.content['Contact Emails'])

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -360,7 +360,7 @@ class PaperWithdrawInvitation(openreview.Invitation):
                         ]
                     },
                     'signatures': {
-                        'values-regex': '~.*',
+                        'values-regex': conference.get_authors_id(note.number),
                         'description': 'How your identity will be displayed.'
                     },
                     'content': content

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -224,24 +224,22 @@ class WithdrawInvitation(openreview.Invitation):
 
     def __init__(self, conference):
 
-        content = invitations.withdraw.copy()
+        content = invitations.submission.copy()
+        if (conference.double_blind):
+            content['authors'] = {
+                'values': ['Anonymous']
+            }
+            content['authorids'] = {
+                'values-regex': '.*'
+            }
 
         super(WithdrawInvitation, self).__init__(
             id=conference.get_invitation_id('Withdrawn_Submission'),
-            cdate=tools.datetime_millis(conference.submission_stage.due_date),
+            # cdate=tools.datetime_millis(conference.submission_stage.due_date),
             readers=['everyone'],
             writers=[conference.get_id()],
             signatures=[conference.get_id()],
-            reply={
-                'content': {
-                    'authors': {
-                        'values': ['Anonymous']
-                    },
-                    'authorids': {
-                        'values-regex': '.*'
-                    }
-                }
-            }
+            reply=content
         )
 
 class PaperWithdrawInvitation(openreview.Invitation):

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -702,15 +702,10 @@ class InvitationBuilder(object):
 
     def set_submission_invitation(self, conference):
 
-        if not conference.submission_stage.double_blind and conference.submission_stage.allow_withdraw:
-            self.set_withdraw_invitation(conference)
         return self.client.post_invitation(SubmissionInvitation(conference))
 
 
     def set_blind_submission_invitation(self, conference):
-
-        if conference.submission_stage.allow_withdraw:
-            self.set_withdraw_invitation(conference)
 
         invitation = BlindSubmissionsInvitation(conference = conference)
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -298,7 +298,7 @@ class WithdrawnSubmissionInvitation(openreview.Invitation):
 
         super(WithdrawnSubmissionInvitation, self).__init__(
             id=conference.get_invitation_id('Withdrawn_Submission'),
-            # cdate=tools.datetime_millis(conference.submission_stage.due_date),
+            cdate=tools.datetime_millis(conference.submission_stage.due_date),
             readers=['everyone'],
             writers=[conference.get_id()],
             signatures=[conference.get_id()],
@@ -346,7 +346,7 @@ class PaperWithdrawInvitation(openreview.Invitation):
 
             super(PaperWithdrawInvitation, self).__init__(
                 id=conference.get_invitation_id('Withdraw', note.number),
-                # cdate=tools.datetime_millis(conference.submission_stage.due_date),
+                cdate=tools.datetime_millis(conference.submission_stage.due_date),
                 duedate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 80)),
                 expdate = tools.datetime_millis(conference.submission_stage.due_date + datetime.timedelta(days = 90)),
                 invitees=[conference.get_authors_id(note.number)],
@@ -710,14 +710,15 @@ class InvitationBuilder(object):
 
     def set_submission_invitation(self, conference):
 
-        # if not conference.submission_stage.double_blind:
-        #     self.set_withdraw_invitation(conference)
+        if not conference.submission_stage.double_blind and conference.submission_stage.allow_withdraw:
+            self.set_withdraw_invitation(conference)
         return self.client.post_invitation(SubmissionInvitation(conference))
 
 
     def set_blind_submission_invitation(self, conference):
 
-        self.set_withdraw_invitation(conference)
+        if conference.submission_stage.allow_withdraw:
+            self.set_withdraw_invitation(conference)
 
         invitation = BlindSubmissionsInvitation(conference = conference)
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -33,15 +33,10 @@ class SubmissionInvitation(openreview.Invitation):
 
         for field in submission_stage.remove_fields:
             del content[field]
-        print ('yahoo from sub stage class!!')
-        print ('got addn fields')
-        print (additional_fields)
-        print ('content before update:', content.keys())
         for order, key in enumerate(additional_fields, start=10):
             value = additional_fields[key]
             value['order'] = order
             content[key] = value
-        print ('\n\ncontent after update:', content.keys())
         with open(os.path.join(os.path.dirname(__file__), 'templates/submissionProcess.js')) as f:
             file_content = f.read()
             file_content = file_content.replace("var SHORT_PHRASE = '';", "var SHORT_PHRASE = '" + conference.get_short_name() + "';")
@@ -281,20 +276,17 @@ class WithdrawnSubmissionInvitation(openreview.Invitation):
 
     def __init__(self, conference, withdrawn_submission_content=None):
 
-        print ('yaaaahoooo!!')
-        print ('with_content:')
-        print (withdrawn_submission_content)
         content = invitations.submission.copy()
         if withdrawn_submission_content:
             content = withdrawn_submission_content
 
-        # if (conference.submission_stage.double_blind and not conference.submission_stage.reveal_authors_on_withdraw):
-        content['authors'] = {
-            'values': ['Anonymous']
-        }
-        content['authorids'] = {
-            'values-regex': '.*'
-        }
+        if (conference.submission_stage.double_blind and not conference.submission_stage.reveal_authors_on_withdraw):
+            content['authors'] = {
+                'values': ['Anonymous']
+            }
+            content['authorids'] = {
+                'values-regex': '.*'
+            }
 
         super(WithdrawnSubmissionInvitation, self).__init__(
             id=conference.get_invitation_id('Withdrawn_Submission'),
@@ -757,9 +749,6 @@ class InvitationBuilder(object):
 
         submission_invitation = self.client.get_invitation(id = conference.get_submission_id())
         withdrawn_submission_content = submission_invitation.reply['content']
-
-        print ('before sending!!!')
-        print (withdrawn_submission_content)
 
         self.client.post_invitation(WithdrawnSubmissionInvitation(conference, withdrawn_submission_content))
 

--- a/openreview/conference/invitation.py
+++ b/openreview/conference/invitation.py
@@ -289,7 +289,7 @@ class WithdrawnSubmissionInvitation(openreview.Invitation):
             }
 
         super(WithdrawnSubmissionInvitation, self).__init__(
-            id=conference.get_invitation_id('Withdrawn_Submission'),
+            id=conference.submission_stage.get_withdrawn_submission_id(),
             cdate=tools.datetime_millis(conference.submission_stage.due_date),
             readers=['everyone'],
             writers=[conference.get_id()],

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -3,4 +3,4 @@ def process(client, note, invitation):
     REVEAL_AUTHORS_ON_WITHDRAW = ''
     blind_note = client.get_note(note.forum)
     blind_note.invitation = WITHDRAWN_SUBMISSION_ID
-    client.post_note(note)
+    client.post_note(blind_note)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -1,6 +1,10 @@
 def process(client, note, invitation):
     WITHDRAWN_SUBMISSION_ID = ''
-    REVEAL_AUTHORS_ON_WITHDRAW = ''
+    REVEAL_AUTHORS_ON_WITHDRAW = False
     blind_note = client.get_note(note.forum)
     blind_note.invitation = WITHDRAWN_SUBMISSION_ID
+    if REVEAL_AUTHORS_ON_WITHDRAW:
+        original_note = client.get_note(id = blind_note.original)
+        blind_note.content['authors'] = original_note.content['authors']
+        blind_note.content['authorids'] = original_note.content['authorids']
     client.post_note(blind_note)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -1,5 +1,6 @@
 def process(client, note, invitation):
     WITHDRAWN_SUBMISSION_ID = ''
+    REVEAL_AUTHORS_ON_WITHDRAW = ''
     blind_note = client.get_note(note.forum)
     blind_note.invitation = WITHDRAWN_SUBMISSION_ID
     client.post_note(note)

--- a/openreview/conference/templates/withdraw_process.py
+++ b/openreview/conference/templates/withdraw_process.py
@@ -1,0 +1,5 @@
+def process(client, note, invitation):
+    WITHDRAWN_SUBMISSION_ID = ''
+    blind_note = client.get_note(note.forum)
+    blind_note.invitation = WITHDRAWN_SUBMISSION_ID
+    client.post_note(note)

--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -28,6 +28,23 @@ comment = {
         'required': True
     }
 }
+
+withdraw = {
+    'title': {
+        'value': 'Submission Withdrawn by the Authors',
+        'order': 1
+    },
+    'withdrawal confirmation': {
+        'description':
+        'value-radio': [
+            'I have read and agree with the withdrawal statement on behalf of myself and my co-authors.'
+        ],
+        'order': 2,
+        'required': True
+    }
+}
+
+
 review_rating = {
     'title': {
         'order': 1,

--- a/openreview/invitations/content.py
+++ b/openreview/invitations/content.py
@@ -35,9 +35,9 @@ withdraw = {
         'order': 1
     },
     'withdrawal confirmation': {
-        'description':
+        'description': 'Please confirm to withdraw.',
         'value-radio': [
-            'I have read and agree with the withdrawal statement on behalf of myself and my co-authors.'
+            'I have read and agree with the venue\'s withdrawal policy on behalf of myself and my co-authors.'
         ],
         'order': 2,
         'required': True


### PR DESCRIPTION
Allows authors to withdraw their submissions.
Uses class SubmissionStage's attributes "allow_withdraw" and "reveal_authors_on_withdraw" while enabling withdraw invitations.
Creates 1 conference level CONF_ID+"Withdrawn_Submissions" invitation and then a per paper invitation names CONF_ID+"Paper<paper-number>/Withdraw".