### PR TITLE
Fix/reviewer reassignment

### DIFF
--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -1601,18 +1601,24 @@ $('#group-container').on('click', 'a.unassign-reviewer-link', function(e) {
 
   Webfield.delete('/groups/members', {
     id: CONFERENCE_ID + '/Paper' + paperNumber + '/Reviewers',
-    members: [reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id, reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email]
+    members: [
+      reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id,
+      reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email
+    ]
   })
   .then(function(result) {
     return Webfield.delete('/groups/members', {
       id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + reviewerNumber,
-      members: [reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id, reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email]
+      members: [
+        reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id,
+        reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email
+      ]
     });
   })
   .then(function(result) {
     var currentReviewerToPapersMap = conferenceStatusData.reviewerGroups.byReviewers[userId];
 
-    if (currentReviewerToPapersMap.length === 1) {
+    if (currentReviewerToPapersMap && (currentReviewerToPapersMap.length === 1)) {
       delete conferenceStatusData.reviewerGroups.byReviewers[userId];
     } else {
       conferenceStatusData.reviewerGroups.byReviewers[userId] = currentReviewerToPapersMap.filter(function(number) {

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -1665,7 +1665,7 @@ $('#group-container').on('click', 'a.unassign-reviewer-link', function(e) {
   .then(function(result) {
     var currentReviewerToPapersMap = conferenceStatusData.reviewerGroups.byReviewers[userId];
 
-    if (currentReviewerToPapersMap && (currentReviewerToPapersMap.length === 1)) {
+    if (currentReviewerToPapersMap.length === 1) {
       delete conferenceStatusData.reviewerGroups.byReviewers[userId];
     } else {
       conferenceStatusData.reviewerGroups.byReviewers[userId] = currentReviewerToPapersMap.filter(function(number) {

--- a/openreview/conference/templates/programchairWebfield.js
+++ b/openreview/conference/templates/programchairWebfield.js
@@ -206,6 +206,7 @@ var getUserProfiles = function(userIds) {
       var name = _.find(profile.content.names, ['preferred', true]) || _.first(profile.content.names);
       profile.name = _.isEmpty(name) ? view.prettyId(profile.id) : name.first + ' ' + name.last;
       profile.email = profile.content.preferredEmail || profile.content.emails[0];
+      profile.allEmails = profile.content.emails;
       profileMap[profile.id] = profile;
     };
     if (searchResults.length) {
@@ -1645,20 +1646,20 @@ $('#group-container').on('click', 'a.unassign-reviewer-link', function(e) {
   var paperNumber = $link.data('paperNumber');
   var reviewerNumber = $link.data('reviewerNumber');
 
+  var membersToDelete = [
+    reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id
+  ];
+  _.forEach(reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].allEmails, function(email){
+    membersToDelete.push(email);
+  });
   Webfield.delete('/groups/members', {
     id: CONFERENCE_ID + '/Paper' + paperNumber + '/Reviewers',
-    members: [
-      reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id,
-      reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email
-    ]
+    members: membersToDelete
   })
   .then(function(result) {
     return Webfield.delete('/groups/members', {
       id: CONFERENCE_ID + '/Paper' + paperNumber + '/AnonReviewer' + reviewerNumber,
-      members: [
-        reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].id,
-        reviewerSummaryMap[paperNumber].reviewers[reviewerNumber].email
-      ]
+      members: membersToDelete
     });
   })
   .then(function(result) {


### PR DESCRIPTION
This fixes a bug in reviewer reassignment on PC console.
Bug description: When the paper reviewer and paper anonReviewer group are populated with a reviewers non-preferred email, unassign operation on PC console fails as it tries to only remove the members: [profile.id, profile.preferredEmail].